### PR TITLE
Adds headlines to allow creation of toc

### DIFF
--- a/docs/book/index.md
+++ b/docs/book/index.md
@@ -1,3 +1,7 @@
+# Basic Usage
+
+## Installation
+
 ```bash
 $ composer require --dev laminas/laminas-component-installer
 ```


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes

### Description

A first headline (`h1`) is needed for the Markdown TOC extension to output a table of contents.

