### PR TITLE
Psalm integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ matrix:
       env:
         - DEPS=latest
         - COMPOSER_VERSION=2
+        - STATIC_ANALYSIS=true
     - php: nightly
       env:
         - DEPS=lowest
@@ -62,6 +63,7 @@ install:
 
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer run-script test-coverage --timeout=400 -- --verbose ; else composer run-script test --timeout=300 -- --verbose ; fi
+  - if [[ $STATIC_ANALYSIS == 'true' ]]; then composer static-analysis ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer license-check ; fi
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,9 @@
         "malukenho/docheader": "^0.1.6",
         "mikey179/vfsstream": "^1.6.7",
         "phpspec/prophecy-phpunit": "^2.0",
-        "phpunit/phpunit": "^9.3"
+        "phpunit/phpunit": "^9.3",
+        "psalm/plugin-phpunit": "^0.13.0",
+        "vimeo/psalm": "^4.2"
     },
     "autoload": {
         "psr-4": {
@@ -56,6 +58,7 @@
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
         "test": "phpunit --colors=always",
+        "static-analysis": "psalm --shepherd --stats",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
         "license-check": "docheader check src/"
     },

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,1069 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.2.1@ea9cb72143b77e7520c52fa37290bd8d8bc88fd9">
+  <file src="src/Collection.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>is_array($items)</code>
+      <code>null === $offset</code>
+    </DocblockTypeContradiction>
+    <MissingClosureParamType occurrences="9">
+      <code>$filtered</code>
+      <code>$filtered</code>
+      <code>$item</code>
+      <code>$item</code>
+      <code>$item</code>
+      <code>$key</code>
+      <code>$key</code>
+      <code>$key</code>
+      <code>$results</code>
+    </MissingClosureParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$items</code>
+    </MissingPropertyType>
+    <MixedArgument occurrences="6">
+      <code>$this-&gt;items</code>
+      <code>$this-&gt;items</code>
+      <code>$this-&gt;items</code>
+      <code>$this-&gt;items</code>
+      <code>$this-&gt;items</code>
+      <code>$this-&gt;items</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="2">
+      <code>$this-&gt;items[$offset]</code>
+      <code>$this-&gt;items[$offset]</code>
+    </MixedArrayAccess>
+    <MixedArrayAssignment occurrences="5">
+      <code>$filtered[$key]</code>
+      <code>$filtered[$key]</code>
+      <code>$results[$key]</code>
+      <code>$this-&gt;items[$offset]</code>
+      <code>$this-&gt;items[]</code>
+    </MixedArrayAssignment>
+    <MixedArrayOffset occurrences="3">
+      <code>$filtered[$key]</code>
+      <code>$filtered[$key]</code>
+      <code>$results[$key]</code>
+    </MixedArrayOffset>
+    <MixedAssignment occurrences="9">
+      <code>$accumulator</code>
+      <code>$accumulator</code>
+      <code>$filtered[$key]</code>
+      <code>$filtered[$key]</code>
+      <code>$item</code>
+      <code>$item</code>
+      <code>$key</code>
+      <code>$key</code>
+      <code>$results[$key]</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="4">
+      <code>array</code>
+      <code>static</code>
+      <code>static</code>
+      <code>static</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="4">
+      <code>$this-&gt;items</code>
+    </MixedReturnStatement>
+    <UnsafeInstantiation occurrences="5">
+      <code>new static($items)</code>
+      <code>new static([])</code>
+      <code>new static([])</code>
+      <code>new static([])</code>
+      <code>new static(array_unique($this-&gt;items))</code>
+    </UnsafeInstantiation>
+  </file>
+  <file src="src/ComponentInstaller.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>is_callable($this-&gt;packageProviderFactory)</code>
+    </DocblockTypeContradiction>
+    <InvalidPropertyAssignmentValue occurrences="1"/>
+    <InvalidScalarArgument occurrences="1">
+      <code>$default</code>
+    </InvalidScalarArgument>
+    <MissingClosureParamType occurrences="30">
+      <code>$allowed</code>
+      <code>$ask</code>
+      <code>$configKey</code>
+      <code>$configKey</code>
+      <code>$configOption</code>
+      <code>$discoveredTypes</code>
+      <code>$index</code>
+      <code>$injector</code>
+      <code>$injector</code>
+      <code>$injectors</code>
+      <code>$key</code>
+      <code>$module</code>
+      <code>$module</code>
+      <code>$module</code>
+      <code>$module</code>
+      <code>$modules</code>
+      <code>$option</code>
+      <code>$option</code>
+      <code>$option</code>
+      <code>$packages</code>
+      <code>$packages</code>
+      <code>$registered</code>
+      <code>$registered</code>
+      <code>$type</code>
+      <code>$type</code>
+      <code>$type</code>
+      <code>$type</code>
+      <code>$type</code>
+      <code>$valid</code>
+      <code>$value</code>
+    </MissingClosureParamType>
+    <MissingClosureReturnType occurrences="5">
+      <code>function ($allowed, $option) {</code>
+      <code>function ($configOption) {</code>
+      <code>function ($injector) use ($packageTypes) {</code>
+      <code>function ($module) use ($options) {</code>
+      <code>function ($modules, $configKey, $type) use ($extra, $supportedTypes) {</code>
+    </MissingClosureReturnType>
+    <MixedArgument occurrences="23">
+      <code>$ask</code>
+      <code>$ask</code>
+      <code>$configKey</code>
+      <code>$index</code>
+      <code>$injector</code>
+      <code>$injector</code>
+      <code>$item</code>
+      <code>$map</code>
+      <code>$module</code>
+      <code>$module</code>
+      <code>$module</code>
+      <code>$module</code>
+      <code>$module</code>
+      <code>$name</code>
+      <code>$option-&gt;getPromptText()</code>
+      <code>$package-&gt;getExtra()</code>
+      <code>$packageProviderDetection</code>
+      <code>$packageType</code>
+      <code>$packageTypes[$module]</code>
+      <code>$path</code>
+      <code>$supportedTypes</code>
+      <code>$value</code>
+      <code>$whitelist</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="4">
+      <code>$extra</code>
+      <code>$extra</code>
+      <code>$namespace</code>
+      <code>$type</code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAssignment occurrences="4">
+      <code>$ask[]</code>
+      <code>$ask[]</code>
+      <code>$discoveredTypes[$package]</code>
+      <code>$injectors[$module]</code>
+    </MixedArrayAssignment>
+    <MixedArrayOffset occurrences="6">
+      <code>$dependencies[$module]</code>
+      <code>$discoveredTypes[$package]</code>
+      <code>$extra[$configKey]</code>
+      <code>$packageTypes[$module]</code>
+      <code>$packageTypes[$module]</code>
+      <code>$packageTypes[$type]</code>
+    </MixedArrayOffset>
+    <MixedAssignment occurrences="13">
+      <code>$ask</code>
+      <code>$injector</code>
+      <code>$map</code>
+      <code>$name</code>
+      <code>$package</code>
+      <code>$package</code>
+      <code>$packageProviderDetection</code>
+      <code>$packageType</code>
+      <code>$path</code>
+      <code>$paths</code>
+      <code>$supportedTypes</code>
+      <code>$this-&gt;packageProviderFactory</code>
+      <code>$whitelist</code>
+    </MixedAssignment>
+    <MixedFunctionCall occurrences="1">
+      <code>($this-&gt;packageProviderFactory)()</code>
+    </MixedFunctionCall>
+    <MixedInferredReturnType occurrences="4">
+      <code>Collection</code>
+      <code>Collection</code>
+      <code>Injector\InjectorInterface</code>
+      <code>bool</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="20">
+      <code>getExtra</code>
+      <code>getInjector</code>
+      <code>getInjector</code>
+      <code>getInjector</code>
+      <code>getInjector</code>
+      <code>getInjector</code>
+      <code>getInjector</code>
+      <code>getInjector</code>
+      <code>getName</code>
+      <code>getPromptText</code>
+      <code>getTypesAllowed</code>
+      <code>isRegistered</code>
+      <code>merge</code>
+      <code>merge</code>
+      <code>registersType</code>
+      <code>setApplicationModules</code>
+      <code>setModuleDependencies</code>
+      <code>toArray</code>
+      <code>unique</code>
+      <code>unique</code>
+    </MixedMethodCall>
+    <MixedReturnStatement occurrences="5">
+      <code>$options[1]-&gt;getInjector()</code>
+      <code>isset($options[2]) ? $options[2]-&gt;getInjector() : $options[1]-&gt;getInjector()</code>
+    </MixedReturnStatement>
+    <PossiblyNullArgument occurrences="1">
+      <code>$this-&gt;io-&gt;ask(implode($ask), 'y')</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$composer</code>
+      <code>$io</code>
+      <code>$packageProviderFactory</code>
+      <code>$projectRoot</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="3">
+      <code>is_string($module)</code>
+      <code>is_string($projectRoot)</code>
+      <code>is_string($this-&gt;projectRoot)</code>
+    </RedundantConditionGivenDocblockType>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getPackage</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="src/ConfigDiscovery.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>is_array($injectorClass)</code>
+    </DocblockTypeContradiction>
+    <InvalidPropertyAssignmentValue occurrences="2"/>
+    <InvalidStringClass occurrences="1">
+      <code>new $injectorClass($projectRoot)</code>
+    </InvalidStringClass>
+    <MissingClosureParamType occurrences="9">
+      <code>$discovery</code>
+      <code>$discovery</code>
+      <code>$discoveryClass</code>
+      <code>$file</code>
+      <code>$file</code>
+      <code>$flag</code>
+      <code>$injector</code>
+      <code>$injector</code>
+      <code>$type</code>
+    </MissingClosureParamType>
+    <MissingClosureReturnType occurrences="2">
+      <code>function ($discovery) {</code>
+      <code>function ($injector) use ($availableTypes) {</code>
+    </MissingClosureReturnType>
+    <MixedArgument occurrences="2">
+      <code>$file</code>
+      <code>$injector</code>
+    </MixedArgument>
+    <MixedArrayOffset occurrences="1">
+      <code>$this-&gt;injectors[$file]</code>
+    </MixedArrayOffset>
+    <MixedMethodCall occurrences="3">
+      <code>locate</code>
+      <code>new $discoveryClass($projectRoot)</code>
+      <code>registersType</code>
+    </MixedMethodCall>
+    <NullArgument occurrences="1">
+      <code>$discovered</code>
+    </NullArgument>
+  </file>
+  <file src="src/ConfigDiscovery/AbstractDiscovery.php">
+    <PossiblyNullArgument occurrences="1">
+      <code>$this-&gt;configFile</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$configFile</code>
+      <code>$expected</code>
+    </PropertyNotSetInConstructor>
+    <UninitializedProperty occurrences="1">
+      <code>$this-&gt;configFile</code>
+    </UninitializedProperty>
+  </file>
+  <file src="src/ConfigDiscovery/ConfigAggregator.php">
+    <MissingParamType occurrences="1">
+      <code>$projectDirectory</code>
+    </MissingParamType>
+    <MixedArgument occurrences="1">
+      <code>$projectDirectory</code>
+    </MixedArgument>
+  </file>
+  <file src="src/ConfigDiscovery/DiscoveryChain.php">
+    <MissingClosureParamType occurrences="2">
+      <code>$discovery</code>
+      <code>$discoveryClass</code>
+    </MissingClosureParamType>
+    <MissingClosureReturnType occurrences="1">
+      <code>function ($discovery) {</code>
+    </MissingClosureReturnType>
+    <MixedMethodCall occurrences="2">
+      <code>locate</code>
+      <code>new $discoveryClass($projectDirectory)</code>
+    </MixedMethodCall>
+  </file>
+  <file src="src/ConfigDiscovery/MezzioConfig.php">
+    <MissingParamType occurrences="1">
+      <code>$projectDirectory</code>
+    </MissingParamType>
+    <MixedArgument occurrences="1">
+      <code>$projectDirectory</code>
+    </MixedArgument>
+  </file>
+  <file src="src/Injector/AbstractInjector.php">
+    <InvalidArrayOffset occurrences="6">
+      <code>$this-&gt;injectionPatterns[$type]['pattern']</code>
+      <code>$this-&gt;injectionPatterns[$type]['replacement']</code>
+      <code>$this-&gt;injectionPatterns[self::TYPE_BEFORE_APPLICATION]['pattern']</code>
+      <code>$this-&gt;injectionPatterns[self::TYPE_BEFORE_APPLICATION]['replacement']</code>
+      <code>$this-&gt;injectionPatterns[self::TYPE_DEPENDENCY]['pattern']</code>
+      <code>$this-&gt;injectionPatterns[self::TYPE_DEPENDENCY]['replacement']</code>
+    </InvalidArrayOffset>
+    <MissingPropertyType occurrences="1">
+      <code>$allowedTypes</code>
+    </MissingPropertyType>
+    <MixedArgument occurrences="12">
+      <code>$dependency</code>
+      <code>$dependency</code>
+      <code>$dependency</code>
+      <code>$module</code>
+      <code>$module</code>
+      <code>$pattern</code>
+      <code>$this-&gt;allowedTypes</code>
+      <code>$this-&gt;injectionPatterns[$type]['replacement']</code>
+      <code>$this-&gt;injectionPatterns[self::TYPE_BEFORE_APPLICATION]['pattern']</code>
+      <code>$this-&gt;injectionPatterns[self::TYPE_BEFORE_APPLICATION]['replacement']</code>
+      <code>$this-&gt;injectionPatterns[self::TYPE_DEPENDENCY]['pattern']</code>
+      <code>$this-&gt;injectionPatterns[self::TYPE_DEPENDENCY]['replacement']</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="6">
+      <code>$dependency</code>
+      <code>$dependency</code>
+      <code>$first</code>
+      <code>$last</code>
+      <code>$module</code>
+      <code>$pattern</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="3">
+      <code>getTypesAllowed</code>
+      <code>string</code>
+      <code>string|null</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="4">
+      <code>$first</code>
+      <code>$last</code>
+      <code>$this-&gt;allowedTypes</code>
+      <code>reset($dependencies)</code>
+    </MixedReturnStatement>
+    <NullableReturnStatement occurrences="1">
+      <code>$last</code>
+    </NullableReturnStatement>
+    <PossiblyNullArgument occurrences="1">
+      <code>$this-&gt;configFile</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$configFile</code>
+      <code>$isRegisteredPattern</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>is_string($projectRoot)</code>
+    </RedundantConditionGivenDocblockType>
+    <UninitializedProperty occurrences="1">
+      <code>$this-&gt;configFile</code>
+    </UninitializedProperty>
+  </file>
+  <file src="src/Injector/ApplicationConfigInjector.php">
+    <InvalidPropertyAssignmentValue occurrences="1"/>
+  </file>
+  <file src="src/Injector/ConditionalDiscoveryTrait.php">
+    <InvalidStringClass occurrences="1">
+      <code>new $discoveryClass($this-&gt;getProjectRoot())</code>
+    </InvalidStringClass>
+    <MixedInferredReturnType occurrences="1">
+      <code>bool</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="1">
+      <code>locate</code>
+    </MixedMethodCall>
+    <MixedOperand occurrences="1">
+      <code>static::DEFAULT_CONFIG_FILE</code>
+    </MixedOperand>
+  </file>
+  <file src="src/Injector/ConfigAggregatorInjector.php">
+    <InvalidArrayOffset occurrences="1">
+      <code>$this-&gt;injectionPatterns[self::TYPE_CONFIG_PROVIDER]['pattern']</code>
+    </InvalidArrayOffset>
+    <InvalidPropertyAssignmentValue occurrences="2">
+      <code>$this-&gt;injectionPatterns</code>
+    </InvalidPropertyAssignmentValue>
+    <MissingParamType occurrences="1">
+      <code>$projectRoot</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$allowedTypes</code>
+    </MissingPropertyType>
+    <MixedArgument occurrences="1">
+      <code>$projectRoot</code>
+    </MixedArgument>
+  </file>
+  <file src="src/Injector/ConfigInjectorChain.php">
+    <MissingClosureParamType occurrences="9">
+      <code>$file</code>
+      <code>$flag</code>
+      <code>$injector</code>
+      <code>$injector</code>
+      <code>$injector</code>
+      <code>$injector</code>
+      <code>$injector</code>
+      <code>$injector</code>
+      <code>$type</code>
+    </MissingClosureParamType>
+    <MissingClosureReturnType occurrences="2">
+      <code>function ($injector) use ($availableTypes) {</code>
+      <code>function ($injector) use ($package) {</code>
+    </MissingClosureReturnType>
+    <MissingPropertyType occurrences="1">
+      <code>$allowedTypes</code>
+    </MissingPropertyType>
+    <MixedArgument occurrences="1">
+      <code>$file</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$allowedTypes</code>
+      <code>$injector</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="3">
+      <code>getTypesAllowed</code>
+      <code>inject</code>
+      <code>remove</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="6">
+      <code>getTypesAllowed</code>
+      <code>inject</code>
+      <code>isRegistered</code>
+      <code>new $injector($projectRoot)</code>
+      <code>registersType</code>
+      <code>remove</code>
+    </MixedMethodCall>
+    <MixedOperand occurrences="1">
+      <code>$injector-&gt;getTypesAllowed()</code>
+    </MixedOperand>
+    <MixedReturnStatement occurrences="4">
+      <code>$allowedTypes</code>
+      <code>$injected</code>
+      <code>$removed</code>
+      <code>$this-&gt;allowedTypes</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/Injector/MezzioConfigInjector.php">
+    <InvalidArrayOffset occurrences="1">
+      <code>$this-&gt;injectionPatterns[self::TYPE_CONFIG_PROVIDER]['pattern']</code>
+    </InvalidArrayOffset>
+    <InvalidPropertyAssignmentValue occurrences="2">
+      <code>$this-&gt;injectionPatterns</code>
+    </InvalidPropertyAssignmentValue>
+    <MissingParamType occurrences="1">
+      <code>$projectRoot</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$allowedTypes</code>
+    </MissingPropertyType>
+    <MixedArgument occurrences="1">
+      <code>$projectRoot</code>
+    </MixedArgument>
+  </file>
+  <file src="src/PackageProvider/ComposerV2.php">
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$installedRepository</code>
+    </InvalidPropertyAssignmentValue>
+    <MixedInferredReturnType occurrences="1">
+      <code>array</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;installedRepository-&gt;findPackagesWithReplacersAndProviders($packageName)</code>
+    </MixedReturnStatement>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>findPackagesWithReplacersAndProviders</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="src/PackageProvider/PackageProviderDetectionFactory.php">
+    <MixedArgument occurrences="2">
+      <code>$event-&gt;getPool()</code>
+      <code>$platformOverrides</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$platformOverrides</code>
+    </MixedAssignment>
+    <UndefinedMethod occurrences="1">
+      <code>getPool</code>
+    </UndefinedMethod>
+  </file>
+  <file src="test/ComponentInstallerTest.php">
+    <ImplicitToStringCast occurrences="47">
+      <code>Argument::any()</code>
+      <code>Argument::that($askValidator)</code>
+      <code>Argument::that($askValidator)</code>
+    </ImplicitToStringCast>
+    <InvalidArgument occurrences="4">
+      <code>Argument::exact($package-&gt;reveal())</code>
+      <code>Argument::exact($package-&gt;reveal())</code>
+      <code>Argument::that([$package, 'reveal'])</code>
+      <code>Argument::type(RootPackageRepository::class)</code>
+    </InvalidArgument>
+    <InvalidScalarArgument occurrences="31">
+      <code>1</code>
+      <code>1</code>
+      <code>1</code>
+      <code>1</code>
+      <code>1</code>
+      <code>1</code>
+      <code>1</code>
+      <code>1</code>
+      <code>1</code>
+      <code>1</code>
+      <code>1</code>
+      <code>1</code>
+      <code>1</code>
+      <code>1</code>
+    </InvalidScalarArgument>
+    <MissingClosureParamType occurrences="45">
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+    </MissingClosureParamType>
+    <MissingParamType occurrences="1">
+      <code>$argument</code>
+    </MissingParamType>
+    <MixedArgument occurrences="40">
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$argument</code>
+      <code>$configName</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$pathToModule</code>
+      <code>$this-&gt;composer-&gt;reveal()</code>
+      <code>$this-&gt;io-&gt;reveal()</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>[$package, 'reveal']</code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAccess occurrences="8">
+      <code>$config['modules']</code>
+      <code>$config['modules']</code>
+      <code>$config['modules']</code>
+      <code>$config['modules']</code>
+      <code>$config['modules']</code>
+      <code>$config['modules']</code>
+      <code>$config['modules']</code>
+      <code>$config['modules']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="19">
+      <code>$config</code>
+      <code>$config</code>
+      <code>$config</code>
+      <code>$config</code>
+      <code>$config</code>
+      <code>$config</code>
+      <code>$config</code>
+      <code>$config</code>
+      <code>$configName</code>
+      <code>$dependencies</code>
+      <code>$dependencies</code>
+      <code>$modules</code>
+      <code>$modules</code>
+      <code>$modules</code>
+      <code>$modules</code>
+      <code>$modules</code>
+      <code>$modules</code>
+      <code>$modules</code>
+      <code>$modules</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>array</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="90">
+      <code>shouldBeCalledTimes</code>
+      <code>shouldNotBeCalled</code>
+      <code>will</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyInvalidMethodCall occurrences="3">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="2">
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+    <PossiblyUndefinedVariable occurrences="2">
+      <code>$autoload</code>
+      <code>$pathToModule</code>
+    </PossiblyUndefinedVariable>
+    <UnresolvableInclude occurrences="8">
+      <code>include vfsStream::url('project/config/application.config.php')</code>
+      <code>include vfsStream::url('project/config/application.config.php')</code>
+      <code>include vfsStream::url('project/config/application.config.php')</code>
+      <code>include vfsStream::url('project/config/application.config.php')</code>
+      <code>include vfsStream::url('project/config/application.config.php')</code>
+      <code>include vfsStream::url('project/config/development.config.php')</code>
+      <code>include vfsStream::url('project/config/modules.config.php')</code>
+      <code>include vfsStream::url('project/config/modules.config.php')</code>
+    </UnresolvableInclude>
+  </file>
+  <file src="test/ConfigDiscoveryTest.php">
+    <InternalClass occurrences="6">
+      <code>new ExpectationFailedException('Options array does not contain a NoopInjector!')</code>
+      <code>new ExpectationFailedException('Options array is empty; no NoopInjector found!')</code>
+    </InternalClass>
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>new ConfigDiscovery()</code>
+    </InvalidPropertyAssignmentValue>
+    <MixedArgument occurrences="4">
+      <code>$options</code>
+      <code>$options</code>
+      <code>$options</code>
+      <code>$options</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$options</code>
+      <code>$options</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getInjector</code>
+    </MixedMethodCall>
+    <UndefinedDocblockClass occurrences="5">
+      <code>$this-&gt;discovery</code>
+      <code>$this-&gt;discovery</code>
+      <code>$this-&gt;discovery</code>
+      <code>$this-&gt;discovery</code>
+      <code>ConfigDiscovery\</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="test/Injector/AbstractInjectorTestCase.php">
+    <InvalidStringClass occurrences="1"/>
+    <PropertyTypeCoercion occurrences="1"/>
+  </file>
+  <file src="test/Injector/TestAsset/legacy-mezzio-application-fqcn.config.php">
+    <MixedAssignment occurrences="1">
+      <code>$configManager</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getMergedConfig</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="2">
+      <code>Application\ConfigProvider</code>
+      <code>Mezzio\ConfigManager\ConfigManager</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Injector/TestAsset/legacy-mezzio-application-globally-qualified.config.php">
+    <MixedAssignment occurrences="1">
+      <code>$configManager</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getMergedConfig</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="2">
+      <code>\Application\ConfigProvider</code>
+      <code>\Mezzio\ConfigManager\ConfigManager</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Injector/TestAsset/legacy-mezzio-application-import.config.php">
+    <MixedAssignment occurrences="1">
+      <code>$configManager</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getMergedConfig</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="2">
+      <code>Application\ConfigProvider</code>
+      <code>ConfigManager</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Injector/TestAsset/legacy-mezzio-empty-fqcn.config.php">
+    <MixedAssignment occurrences="1">
+      <code>$configManager</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getMergedConfig</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="1">
+      <code>Mezzio\ConfigManager\ConfigManager</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Injector/TestAsset/legacy-mezzio-empty-globally-qualified.config.php">
+    <MixedAssignment occurrences="1">
+      <code>$configManager</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getMergedConfig</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="1">
+      <code>\Mezzio\ConfigManager\ConfigManager</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Injector/TestAsset/legacy-mezzio-empty-import.config.php">
+    <MixedAssignment occurrences="1">
+      <code>$configManager</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getMergedConfig</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="1">
+      <code>ConfigManager</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Injector/TestAsset/legacy-mezzio-populated-fqcn.config.php">
+    <MixedAssignment occurrences="1">
+      <code>$configManager</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getMergedConfig</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="3">
+      <code>Application\ConfigProvider</code>
+      <code>Mezzio\ConfigManager\ConfigManager</code>
+      <code>\Foo\Bar</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Injector/TestAsset/legacy-mezzio-populated-globally-qualified.config.php">
+    <MixedAssignment occurrences="1">
+      <code>$configManager</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getMergedConfig</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="3">
+      <code>\Application\ConfigProvider</code>
+      <code>\Foo\Bar</code>
+      <code>\Mezzio\ConfigManager\ConfigManager</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Injector/TestAsset/legacy-mezzio-populated-import.config.php">
+    <MixedAssignment occurrences="1">
+      <code>$configManager</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getMergedConfig</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="3">
+      <code>Application\ConfigProvider</code>
+      <code>ConfigManager</code>
+      <code>\Foo\Bar</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Injector/TestAsset/mezzio-application-fqcn.config.php">
+    <MixedAssignment occurrences="1">
+      <code>$aggregator</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getMergedConfig</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="2">
+      <code>Application\ConfigProvider</code>
+      <code>Laminas\ConfigAggregator\ConfigAggregator</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Injector/TestAsset/mezzio-application-from-skeleton.config.php">
+    <MixedAssignment occurrences="1">
+      <code>$aggregator</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getMergedConfig</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="10">
+      <code>App\ConfigProvider</code>
+      <code>ArrayProvider</code>
+      <code>ConfigAggregator</code>
+      <code>PhpFileProvider</code>
+      <code>PhpFileProvider</code>
+      <code>\Contact\ConfigProvider</code>
+      <code>\Laminas\Filter\ConfigProvider</code>
+      <code>\Laminas\InputFilter\ConfigProvider</code>
+      <code>\Laminas\Mail\ConfigProvider</code>
+      <code>\Laminas\Validator\ConfigProvider</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Injector/TestAsset/mezzio-application-globally-qualified.config.php">
+    <MixedAssignment occurrences="1">
+      <code>$aggregator</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getMergedConfig</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="2">
+      <code>\Application\ConfigProvider</code>
+      <code>\Laminas\ConfigAggregator\ConfigAggregator</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Injector/TestAsset/mezzio-application-import-alt-indent.config.php">
+    <MixedAssignment occurrences="1">
+      <code>$aggregator</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getMergedConfig</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="2">
+      <code>Application\ConfigProvider</code>
+      <code>ConfigAggregator</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Injector/TestAsset/mezzio-application-import.config.php">
+    <MixedAssignment occurrences="1">
+      <code>$aggregator</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getMergedConfig</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="2">
+      <code>Application\ConfigProvider</code>
+      <code>ConfigAggregator</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Injector/TestAsset/mezzio-empty-fqcn.config.php">
+    <MixedAssignment occurrences="1">
+      <code>$aggregator</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getMergedConfig</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="1">
+      <code>Laminas\ConfigAggregator\ConfigAggregator</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Injector/TestAsset/mezzio-empty-globally-qualified.config.php">
+    <MixedAssignment occurrences="1">
+      <code>$aggregator</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getMergedConfig</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="1">
+      <code>\Laminas\ConfigAggregator\ConfigAggregator</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Injector/TestAsset/mezzio-empty-import.config.php">
+    <MixedAssignment occurrences="1">
+      <code>$aggregator</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getMergedConfig</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="1">
+      <code>ConfigAggregator</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Injector/TestAsset/mezzio-populated-fqcn.config.php">
+    <MixedAssignment occurrences="1">
+      <code>$aggregator</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getMergedConfig</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="3">
+      <code>Application\ConfigProvider</code>
+      <code>Laminas\ConfigAggregator\ConfigAggregator</code>
+      <code>\Foo\Bar</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Injector/TestAsset/mezzio-populated-globally-qualified.config.php">
+    <MixedAssignment occurrences="1">
+      <code>$aggregator</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getMergedConfig</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="3">
+      <code>\Application\ConfigProvider</code>
+      <code>\Foo\Bar</code>
+      <code>\Laminas\ConfigAggregator\ConfigAggregator</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Injector/TestAsset/mezzio-populated-import-alt-indent.config.php">
+    <MixedAssignment occurrences="1">
+      <code>$aggregator</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getMergedConfig</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="3">
+      <code>Application\ConfigProvider</code>
+      <code>ConfigAggregator</code>
+      <code>\Foo\Bar</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Injector/TestAsset/mezzio-populated-import.config.php">
+    <MixedAssignment occurrences="1">
+      <code>$aggregator</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getMergedConfig</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="3">
+      <code>Application\ConfigProvider</code>
+      <code>ConfigAggregator</code>
+      <code>\Foo\Bar</code>
+    </UndefinedClass>
+  </file>
+</files>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
+>
+    <projectFiles>
+        <directory name="src"/>
+        <directory name="test"/>
+        <ignoreFiles>
+            <directory name="vendor"/>
+            <directory name="test/TestAsset/"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <InternalMethod>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
+            </errorLevel>
+        </InternalMethod>
+    </issueHandlers>
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+</psalm>

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -36,7 +36,7 @@ class Collection implements
     protected $items;
 
     /**
-     * @param array|Traversable $items
+     * @param iterable $items
      * @throws InvalidArgumentException
      */
     public function __construct($items)
@@ -55,10 +55,10 @@ class Collection implements
     /**
      * Factory method
      *
-     * @param array|Traversable
+     * @param iterable $items
      * @return static
      */
-    public static function create($items)
+    public static function create($items): self
     {
         return new static($items);
     }

--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -156,7 +156,7 @@ class ComponentInstaller implements
         $this->composer = $composer;
         $this->io = $io;
         $this->cachedInjectors = [];
-        $this->packageProviderFactory = function () {
+        $this->packageProviderFactory = function (): PackageProvider\PackageProviderDetectionFactory {
             return PackageProviderDetectionFactory::create($this->composer);
         };
     }
@@ -538,11 +538,10 @@ class ComponentInstaller implements
      *
      * @param Injector\InjectorInterface $injector
      * @param int                        $packageType
-     * return void
      *
      * @todo Will need to store selection in filesystem and remove when all packages are complete
      */
-    private function promptToRememberOption(Injector\InjectorInterface $injector, $packageType)
+    private function promptToRememberOption(Injector\InjectorInterface $injector, $packageType): void
     {
         $ask = ["\n  <question>Remember this option for other packages of the same type? (Y/n)</question>"];
 
@@ -930,11 +929,11 @@ class ComponentInstaller implements
         return true;
     }
 
-    public function deactivate(Composer $composer, IOInterface $io)
+    public function deactivate(Composer $composer, IOInterface $io): void
     {
     }
 
-    public function uninstall(Composer $composer, IOInterface $io)
+    public function uninstall(Composer $composer, IOInterface $io): void
     {
     }
 }

--- a/src/ConfigDiscovery.php
+++ b/src/ConfigDiscovery.php
@@ -82,6 +82,7 @@ class ConfigDiscovery
                 // Look up the injector based on the file type
                 $injectorClass = $this->injectors[$file];
                 if (is_array($injectorClass)) {
+                    /** @psalm-suppress MixedArgument */
                     return new Injector\ConfigInjectorChain(
                         $injectorClass,
                         $discovery,

--- a/src/ConfigDiscovery/DiscoveryChain.php
+++ b/src/ConfigDiscovery/DiscoveryChain.php
@@ -25,8 +25,8 @@ class DiscoveryChain implements DiscoveryInterface, DiscoveryChainInterface
      * Optionally specify project directory; $configFile will be relative to
      * this value.
      *
-     * @param mixed  $discovery
-     * @param string $projectDirectory
+     * @param iterable $discovery
+     * @param string   $projectDirectory
      */
     public function __construct($discovery, $projectDirectory = '')
     {

--- a/src/Injector/AbstractInjector.php
+++ b/src/Injector/AbstractInjector.php
@@ -394,8 +394,8 @@ abstract class AbstractInjector implements InjectorInterface
     /**
      * Is the code item registered in the configuration already?
      *
-     * @var string $package Package name
-     * @var string $config
+     * @param string $package Package name
+     * @param string $config
      * @return bool
      */
     protected function isRegisteredInConfig($package, $config)

--- a/src/Injector/ConfigInjectorChain.php
+++ b/src/Injector/ConfigInjectorChain.php
@@ -37,7 +37,7 @@ class ConfigInjectorChain implements InjectorInterface
      * Optionally accept the project root directory; if non-empty, it is used
      * to prefix the $configFile.
      *
-     * @param mixed $injectors
+     * @param iterable $injectors
      * @param DiscoveryChainInterface $discoveryChain
      * @param Collection $availableTypes
      * @param string $projectRoot

--- a/src/Injector/NoopInjector.php
+++ b/src/Injector/NoopInjector.php
@@ -13,6 +13,7 @@ class NoopInjector implements InjectorInterface
     /**
      * {@inheritDoc}
      *
+     * @param int $type
      * @return true
      */
     public function registersType($type)

--- a/test/ConfigDiscovery/ApplicationConfigTest.php
+++ b/test/ConfigDiscovery/ApplicationConfigTest.php
@@ -29,12 +29,12 @@ class ApplicationConfigTest extends TestCase
         );
     }
 
-    public function testAbsenceOfFileReturnsFalseOnLocate()
+    public function testAbsenceOfFileReturnsFalseOnLocate(): void
     {
         $this->assertFalse($this->locator->locate());
     }
 
-    public function testLocateReturnsFalseWhenFileDoesNotHaveExpectedContents()
+    public function testLocateReturnsFalseWhenFileDoesNotHaveExpectedContents(): void
     {
         vfsStream::newFile('config/application.config.php')
             ->at($this->configDir)
@@ -42,7 +42,10 @@ class ApplicationConfigTest extends TestCase
         $this->assertFalse($this->locator->locate());
     }
 
-    public function validApplicationConfigContents()
+    /**
+     * @psalm-return array<string, array{0: string}>
+     */
+    public function validApplicationConfigContents(): array
     {
         return [
             'long-array'  => ['<' . "?php\nreturn array(\n    'modules' => array(\n    )\n);"],
@@ -52,10 +55,8 @@ class ApplicationConfigTest extends TestCase
 
     /**
      * @dataProvider validApplicationConfigContents
-     *
-     * @param string $contents
      */
-    public function testLocateReturnsTrueWhenFileExistsAndHasExpectedContent($contents)
+    public function testLocateReturnsTrueWhenFileExistsAndHasExpectedContent(string $contents): void
     {
         vfsStream::newFile('config/application.config.php')
             ->at($this->configDir)

--- a/test/ConfigDiscovery/ConfigAggregatorTest.php
+++ b/test/ConfigDiscovery/ConfigAggregatorTest.php
@@ -29,12 +29,12 @@ class ConfigAggregatorTest extends TestCase
         );
     }
 
-    public function testAbsenceOfFileReturnsFalseOnLocate()
+    public function testAbsenceOfFileReturnsFalseOnLocate(): void
     {
         $this->assertFalse($this->locator->locate());
     }
 
-    public function testLocateReturnsFalseWhenFileDoesNotHaveExpectedContents()
+    public function testLocateReturnsFalseWhenFileDoesNotHaveExpectedContents(): void
     {
         vfsStream::newFile('config/config.php')
             ->at($this->configDir)
@@ -42,7 +42,12 @@ class ConfigAggregatorTest extends TestCase
         $this->assertFalse($this->locator->locate());
     }
 
-    public function validMezzioConfigContents()
+    /**
+     * @psalm-return array<string, array{
+     *     0: string
+     * }>
+     */
+    public function validMezzioConfigContents(): array
     {
         // @codingStandardsIgnoreStart
         return [
@@ -58,10 +63,8 @@ class ConfigAggregatorTest extends TestCase
 
     /**
      * @dataProvider validMezzioConfigContents
-     *
-     * @param string $contents
      */
-    public function testLocateReturnsTrueWhenFileExistsAndHasExpectedContent($contents)
+    public function testLocateReturnsTrueWhenFileExistsAndHasExpectedContent(string $contents): void
     {
         vfsStream::newFile('config/config.php')
             ->at($this->configDir)

--- a/test/ConfigDiscovery/DevelopmentConfigTest.php
+++ b/test/ConfigDiscovery/DevelopmentConfigTest.php
@@ -29,12 +29,12 @@ class DevelopmentConfigTest extends TestCase
         );
     }
 
-    public function testAbsenceOfFileReturnsFalseOnLocate()
+    public function testAbsenceOfFileReturnsFalseOnLocate(): void
     {
         $this->assertFalse($this->locator->locate());
     }
 
-    public function testLocateReturnsFalseWhenFileDoesNotHaveExpectedContents()
+    public function testLocateReturnsFalseWhenFileDoesNotHaveExpectedContents(): void
     {
         vfsStream::newFile('config/development.config.php.dist')
             ->at($this->configDir)
@@ -42,7 +42,10 @@ class DevelopmentConfigTest extends TestCase
         $this->assertFalse($this->locator->locate());
     }
 
-    public function validDevelopmentConfigContents()
+    /**
+     * @psalm-return array<string, array{0: string}>
+     */
+    public function validDevelopmentConfigContents(): array
     {
         return [
             'long-array'  => ['<' . "?php\nreturn array(\n    'modules' => array(\n    )\n);"],
@@ -52,10 +55,8 @@ class DevelopmentConfigTest extends TestCase
 
     /**
      * @dataProvider validDevelopmentConfigContents
-     *
-     * @param string $contents
      */
-    public function testLocateReturnsTrueWhenFileExistsAndHasExpectedContent($contents)
+    public function testLocateReturnsTrueWhenFileExistsAndHasExpectedContent(string $contents): void
     {
         vfsStream::newFile('config/development.config.php.dist')
             ->at($this->configDir)

--- a/test/ConfigDiscovery/MezzioConfigTest.php
+++ b/test/ConfigDiscovery/MezzioConfigTest.php
@@ -29,12 +29,12 @@ class MezzioConfigTest extends TestCase
         );
     }
 
-    public function testAbsenceOfFileReturnsFalseOnLocate()
+    public function testAbsenceOfFileReturnsFalseOnLocate(): void
     {
         $this->assertFalse($this->locator->locate());
     }
 
-    public function testLocateReturnsFalseWhenFileDoesNotHaveExpectedContents()
+    public function testLocateReturnsFalseWhenFileDoesNotHaveExpectedContents(): void
     {
         vfsStream::newFile('config/config.php')
             ->at($this->configDir)
@@ -42,7 +42,10 @@ class MezzioConfigTest extends TestCase
         $this->assertFalse($this->locator->locate());
     }
 
-    public function validMezzioConfigContents()
+    /**
+     * @psalm-return array<string, array{0: string}>
+     */
+    public function validMezzioConfigContents(): array
     {
         // @codingStandardsIgnoreStart
         return [
@@ -58,10 +61,8 @@ class MezzioConfigTest extends TestCase
 
     /**
      * @dataProvider validMezzioConfigContents
-     *
-     * @param string $contents
      */
-    public function testLocateReturnsTrueWhenFileExistsAndHasExpectedContent($contents)
+    public function testLocateReturnsTrueWhenFileExistsAndHasExpectedContent(string $contents): void
     {
         vfsStream::newFile('config/config.php')
             ->at($this->configDir)

--- a/test/ConfigDiscovery/ModulesConfigTest.php
+++ b/test/ConfigDiscovery/ModulesConfigTest.php
@@ -29,12 +29,12 @@ class ModulesConfigTest extends TestCase
         );
     }
 
-    public function testAbsenceOfFileReturnsFalseOnLocate()
+    public function testAbsenceOfFileReturnsFalseOnLocate(): void
     {
         $this->assertFalse($this->locator->locate());
     }
 
-    public function testLocateReturnsFalseWhenFileDoesNotHaveExpectedContents()
+    public function testLocateReturnsFalseWhenFileDoesNotHaveExpectedContents(): void
     {
         vfsStream::newFile('config/modules.config.php')
             ->at($this->configDir)
@@ -42,7 +42,10 @@ class ModulesConfigTest extends TestCase
         $this->assertFalse($this->locator->locate());
     }
 
-    public function validModulesConfigContents()
+    /**
+     * @psalm-return array<string, array{0: string}>
+     */
+    public function validModulesConfigContents(): array
     {
         return [
             'long-array'  => ['<' . "?php\nreturn array(\n);"],
@@ -52,10 +55,8 @@ class ModulesConfigTest extends TestCase
 
     /**
      * @dataProvider validModulesConfigContents
-     *
-     * @param string $contents
      */
-    public function testLocateReturnsTrueWhenFileExistsAndHasExpectedContent($contents)
+    public function testLocateReturnsTrueWhenFileExistsAndHasExpectedContent(string $contents): void
     {
         vfsStream::newFile('config/modules.config.php')
             ->at($this->configDir)

--- a/test/ConfigDiscoveryTest.php
+++ b/test/ConfigDiscoveryTest.php
@@ -59,14 +59,14 @@ class ConfigDiscoveryTest extends TestCase
         ];
     }
 
-    public function createApplicationConfig()
+    public function createApplicationConfig(): void
     {
         vfsStream::newFile('config/application.config.php')
             ->at($this->projectRoot)
             ->setContent('<' . "?php\nreturn [\n    'modules' => [\n    ]\n];");
     }
 
-    public function createDevelopmentConfig($dist = true)
+    public function createDevelopmentConfig(bool $dist = true): void
     {
         $configFileName = 'config/development.config.php' . ($dist ? '.dist' : '');
         vfsStream::newFile($configFileName)
@@ -74,33 +74,33 @@ class ConfigDiscoveryTest extends TestCase
             ->setContent('<' . "?php\nreturn [\n    'modules' => [\n    ]\n];");
     }
 
-    public function createDevelopmentWorkConfig()
+    public function createDevelopmentWorkConfig(): void
     {
         $this->createDevelopmentConfig(false);
     }
 
-    public function createAggregatorConfig()
+    public function createAggregatorConfig(): void
     {
         vfsStream::newFile('config/config.php')
             ->at($this->projectRoot)
             ->setContent('<' . "?php\n\$aggregator = new ConfigAggregator([\n]);");
     }
 
-    public function createMezzioConfig()
+    public function createMezzioConfig(): void
     {
         vfsStream::newFile('config/config.php')
             ->at($this->projectRoot)
             ->setContent('<' . "?php\n\$configManager = new ConfigManager([\n]);");
     }
 
-    public function createModulesConfig()
+    public function createModulesConfig(): void
     {
         vfsStream::newFile('config/modules.config.php')
             ->at($this->projectRoot)
             ->setContent('<' . "?php\nreturn [\n]);");
     }
 
-    public function assertOptionsContainsNoopInjector(Collection $options)
+    public function assertOptionsContainsNoopInjector(Collection $options): void
     {
         if ($options->isEmpty()) {
             throw new ExpectationFailedException('Options array is empty; no NoopInjector found!');
@@ -114,7 +114,7 @@ class ConfigDiscoveryTest extends TestCase
         }
     }
 
-    public function assertOptionsContainsInjector($injectorType, Collection $options)
+    public function assertOptionsContainsInjector(string $injectorType, Collection $options): InjectorInterface
     {
         foreach ($options as $option) {
             if (! $option instanceof ConfigOption) {
@@ -135,9 +135,10 @@ class ConfigDiscoveryTest extends TestCase
         ));
     }
 
-    public function assertOptionsContainsInjectorInChain($injectorType, Collection $options)
+    public function assertOptionsContainsInjectorInChain(string $injectorType, Collection $options): void
     {
         $chain = $this->assertOptionsContainsInjector(Injector\ConfigInjectorChain::class, $options);
+        $this->assertInstanceOf(Injector\ConfigInjectorChain::class, $chain);
 
         foreach ($chain->getCollection() as $injector) {
             if (! $injector instanceof InjectorInterface) {
@@ -158,14 +159,14 @@ class ConfigDiscoveryTest extends TestCase
         ));
     }
 
-    public function testGetAvailableConfigOptionsReturnsEmptyArrayWhenNoConfigFilesPresent()
+    public function testGetAvailableConfigOptionsReturnsEmptyArrayWhenNoConfigFilesPresent(): void
     {
         $result = $this->discovery->getAvailableConfigOptions($this->allTypes);
         $this->assertInstanceOf(Collection::class, $result);
         $this->assertTrue($result->isEmpty());
     }
 
-    public function testGetAvailableConfigOptionsReturnsOptionsForEachSupportedPackageType()
+    public function testGetAvailableConfigOptionsReturnsOptionsForEachSupportedPackageType(): void
     {
         $this->createApplicationConfig();
         $this->createDevelopmentConfig();
@@ -182,7 +183,15 @@ class ConfigDiscoveryTest extends TestCase
         }
     }
 
-    public function configFileSubset()
+    /**
+     * @psalm-return array<array-key, array{
+     *     seedMethod: string,
+     *     type: int,
+     *     expected: string,
+     *     chain: bool
+     * }>
+     */
+    public function configFileSubset(): array
     {
         return [
             [
@@ -262,18 +271,13 @@ class ConfigDiscoveryTest extends TestCase
 
     /**
      * @dataProvider configFileSubset
-     *
-     * @param string $seedMethod
-     * @param string $type
-     * @param string $expected
-     * @param bool $chain
      */
     public function testGetAvailableConfigOptionsCanReturnsSubsetOfOptionsBaseOnPackageType(
-        $seedMethod,
-        $type,
-        $expected,
-        $chain
-    ) {
+        string $seedMethod,
+        int $type,
+        string $expected,
+        bool $chain
+    ): void {
         $this->{$seedMethod}();
         $options = $this->discovery->getAvailableConfigOptions(new Collection([$type]), vfsStream::url('project'));
         $this->assertCount(2, $options);
@@ -286,7 +290,7 @@ class ConfigDiscoveryTest extends TestCase
         }
     }
 
-    public function testNoOptionReturnedIfInjectorCannotRegisterType()
+    public function testNoOptionReturnedIfInjectorCannotRegisterType(): void
     {
         $this->createApplicationConfig();
         $options = $this->discovery->getAvailableConfigOptions(

--- a/test/Injector/AbstractInjectorTestCase.php
+++ b/test/Injector/AbstractInjectorTestCase.php
@@ -42,35 +42,37 @@ abstract class AbstractInjectorTestCase extends TestCase
         );
     }
 
-    abstract public function allowedTypes();
+    /**
+     * @psalm-return array<string, array{0: int, 1: bool}>
+     */
+    abstract public function allowedTypes(): array;
 
     /**
      * @dataProvider allowedTypes
-     *
-     * @param string $type
-     * @param bool $expected
      */
-    public function testRegistersTypesReturnsExpectedBooleanBasedOnType($type, $expected)
+    public function testRegistersTypesReturnsExpectedBooleanBasedOnType(int $type, bool $expected): void
     {
         $this->assertSame($expected, $this->injector->registersType($type));
     }
 
-    public function testGetTypesAllowedReturnsListOfAllExpectedTypes()
+    public function testGetTypesAllowedReturnsListOfAllExpectedTypes(): void
     {
         $this->assertEquals($this->injectorTypesAllowed, $this->injector->getTypesAllowed());
     }
 
-    abstract public function injectComponentProvider();
+    /**
+     * @psalm-return array<string, array{0: int, 1: string, 2: string}>
+     */
+    abstract public function injectComponentProvider(): array;
 
     /**
      * @dataProvider injectComponentProvider
-     *
-     * @param string $type
-     * @param string $initialContents
-     * @param string $expectedContents
      */
-    public function testInjectAddsPackageToModulesListInAppropriateLocation($type, $initialContents, $expectedContents)
-    {
+    public function testInjectAddsPackageToModulesListInAppropriateLocation(
+        int $type,
+        string $initialContents,
+        string $expectedContents
+    ): void {
         vfsStream::newFile($this->configFile)
             ->at($this->configDir)
             ->setContent($initialContents);
@@ -82,15 +84,15 @@ abstract class AbstractInjectorTestCase extends TestCase
         $this->assertTrue($injected);
     }
 
-    abstract public function packageAlreadyRegisteredProvider();
+    /**
+     * @psalm-return array<string, array{0: string, 1: int}>
+     */
+    abstract public function packageAlreadyRegisteredProvider(): array;
 
     /**
      * @dataProvider packageAlreadyRegisteredProvider
-     *
-     * @param string $contents
-     * @param string $type
      */
-    public function testInjectDoesNotModifyContentsIfPackageIsAlreadyRegistered($contents, $type)
+    public function testInjectDoesNotModifyContentsIfPackageIsAlreadyRegistered(string $contents, int $type): void
     {
         vfsStream::newFile($this->configFile)
             ->at($this->configDir)
@@ -103,14 +105,15 @@ abstract class AbstractInjectorTestCase extends TestCase
         $this->assertFalse($injected);
     }
 
-    abstract public function emptyConfiguration();
+    /**
+     * @psalm-return array<string, array{0: string}>
+     */
+    abstract public function emptyConfiguration(): array;
 
     /**
      * @dataProvider emptyConfiguration
-     *
-     * @param string $contents
      */
-    public function testRemoveDoesNothingIfPackageIsNotInConfigFile($contents)
+    public function testRemoveDoesNothingIfPackageIsNotInConfigFile(string $contents): void
     {
         vfsStream::newFile($this->configFile)
             ->at($this->configDir)
@@ -120,16 +123,18 @@ abstract class AbstractInjectorTestCase extends TestCase
         $this->assertFalse($removed);
     }
 
-    abstract public function packagePopulatedInConfiguration();
+    /**
+     * @psalm-return array<string, array{0: string, 1: string}>
+     */
+    abstract public function packagePopulatedInConfiguration(): array;
 
     /**
      * @dataProvider packagePopulatedInConfiguration
-     *
-     * @param string $initialContents
-     * @param string $expectedContents
      */
-    public function testRemoveRemovesPackageFromConfigurationWhenFound($initialContents, $expectedContents)
-    {
+    public function testRemoveRemovesPackageFromConfigurationWhenFound(
+        string $initialContents,
+        string $expectedContents
+    ): void {
         vfsStream::newFile($this->configFile)
             ->at($this->configDir)
             ->setContent($initialContents);

--- a/test/Injector/ApplicationConfigInjectorTest.php
+++ b/test/Injector/ApplicationConfigInjectorTest.php
@@ -26,7 +26,13 @@ class ApplicationConfigInjectorTest extends AbstractInjectorTestCase
         ApplicationConfigInjector::TYPE_BEFORE_APPLICATION,
     ];
 
-    public function allowedTypes()
+    /**
+     * @psalm-return array<string, array{
+     *     0: int,
+     *     1: bool
+     * }>
+     */
+    public function allowedTypes(): array
     {
         return [
             'config-provider'            => [ApplicationConfigInjector::TYPE_CONFIG_PROVIDER, false],
@@ -37,7 +43,14 @@ class ApplicationConfigInjectorTest extends AbstractInjectorTestCase
         ];
     }
 
-    public function injectComponentProvider()
+    /**
+     * @psalm-return array<string, array{
+     *     0: int,
+     *     1: string,
+     *     2: string
+     * }>
+     */
+    public function injectComponentProvider(): array
     {
         // @codingStandardsIgnoreStart
         $baseContentsLongArray  = '<' . "?php\nreturn array(\n    'modules' => array(\n        'Application',\n    )\n);";
@@ -51,7 +64,13 @@ class ApplicationConfigInjectorTest extends AbstractInjectorTestCase
         // @codingStandardsIgnoreEnd
     }
 
-    public function packageAlreadyRegisteredProvider()
+    /**
+     * @psalm-return array<string, array{
+     *     0: string,
+     *     1: int
+     * }>
+     */
+    public function packageAlreadyRegisteredProvider(): array
     {
         // @codingStandardsIgnoreStart
         return [
@@ -64,7 +83,10 @@ class ApplicationConfigInjectorTest extends AbstractInjectorTestCase
         // @codingStandardsIgnoreEnd
     }
 
-    public function emptyConfiguration()
+    /**
+     * @psalm-return array<string, array{0: string}>
+     */
+    public function emptyConfiguration(): array
     {
         // @codingStandardsIgnoreStart
         $baseContentsLongArray  = '<' . "?php\nreturn array(\n    'modules' => array(\n        'Application',\n    )\n);";
@@ -77,7 +99,10 @@ class ApplicationConfigInjectorTest extends AbstractInjectorTestCase
         ];
     }
 
-    public function packagePopulatedInConfiguration()
+    /**
+     * @psalm-return array<string, array{0: string, 1: string}>
+     */
+    public function packagePopulatedInConfiguration(): array
     {
         // @codingStandardsIgnoreStart
         $baseContentsLongArray  = '<' . "?php\nreturn array(\n    'modules' => array(\n        'Application',\n    )\n);";

--- a/test/Injector/ConfigAggregatorInjectorTest.php
+++ b/test/Injector/ConfigAggregatorInjectorTest.php
@@ -27,12 +27,15 @@ class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
         ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER,
     ];
 
-    public function convertToShortArraySyntax($contents)
+    public function convertToShortArraySyntax(string $contents): string
     {
         return preg_replace('/array\(([^)]+)\)/s', '[$1]', $contents);
     }
 
-    public function allowedTypes()
+    /**
+     * @psalm-return array<string, array{0: int, 1: bool}>
+     */
+    public function allowedTypes(): array
     {
         return [
             'config-provider' => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, true],
@@ -41,7 +44,10 @@ class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
         ];
     }
 
-    public function injectComponentProvider()
+    /**
+     * @psalm-return array<string, array{0: int, 1: string, 2: string}>
+     */
+    public function injectComponentProvider(): array
     {
         // @codingStandardsIgnoreStart
         $baseContentsFqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/mezzio-application-fqcn.config.php');
@@ -77,7 +83,10 @@ class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
         // @codingStandardsIgnoreEnd
     }
 
-    public function packageAlreadyRegisteredProvider()
+    /**
+     * @psalm-return array<string, array{0: string, 1: int}>
+     */
+    public function packageAlreadyRegisteredProvider(): array
     {
         // @codingStandardsIgnoreStart
         $fqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/mezzio-populated-fqcn.config.php');
@@ -99,7 +108,10 @@ class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
         // @codingStandardsIgnoreEnd
     }
 
-    public function emptyConfiguration()
+    /**
+     * @psalm-return array<string, array{0: string}>
+     */
+    public function emptyConfiguration(): array
     {
         // @codingStandardsIgnoreStart
         $fqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/mezzio-empty-fqcn.config.php');
@@ -121,7 +133,10 @@ class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
         ];
     }
 
-    public function packagePopulatedInConfiguration()
+    /**
+     * @psalm-return array<string, array{0: string, 1: string}>
+     */
+    public function packagePopulatedInConfiguration(): array
     {
         // @codingStandardsIgnoreStart
         $baseContentsFqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/mezzio-populated-fqcn.config.php');
@@ -157,7 +172,7 @@ class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
         // @codingStandardsIgnoreEnd
     }
 
-    public function testProperlyDetectsExistingConfigProviderInConfigWithMixedRelativeAndGloballyQualifiedNames()
+    public function testProperlyDetectsExistingConfigProviderInConfigWithMixedRelativeAndGloballyQualifiedNames(): void
     {
         $contents = file_get_contents(__DIR__ . '/TestAsset/mezzio-application-from-skeleton.config.php');
         vfsStream::newFile('config/config.php')

--- a/test/Injector/DevelopmentConfigInjectorTest.php
+++ b/test/Injector/DevelopmentConfigInjectorTest.php
@@ -26,7 +26,10 @@ class DevelopmentConfigInjectorTest extends AbstractInjectorTestCase
         DevelopmentConfigInjector::TYPE_BEFORE_APPLICATION,
     ];
 
-    public function allowedTypes()
+    /**
+     * @psalm-return array<string, array{0: int, 1: bool}>
+     */
+    public function allowedTypes(): array
     {
         return [
             'config-provider'            => [DevelopmentConfigInjector::TYPE_CONFIG_PROVIDER, false],
@@ -37,7 +40,10 @@ class DevelopmentConfigInjectorTest extends AbstractInjectorTestCase
         ];
     }
 
-    public function injectComponentProvider()
+    /**
+     * @psalm-return array<string, array{0: int, 1: string, 2: string}>
+     */
+    public function injectComponentProvider(): array
     {
         // @codingStandardsIgnoreStart
         $baseContentsLongArray  = '<' . "?php\nreturn array(\n    'modules' => array(\n        'Application',\n    )\n);";
@@ -51,7 +57,10 @@ class DevelopmentConfigInjectorTest extends AbstractInjectorTestCase
         // @codingStandardsIgnoreEnd
     }
 
-    public function packageAlreadyRegisteredProvider()
+    /**
+     * @psalm-return array<string, array{0: string, 1: int}>
+     */
+    public function packageAlreadyRegisteredProvider(): array
     {
         // @codingStandardsIgnoreStart
         return [
@@ -63,7 +72,10 @@ class DevelopmentConfigInjectorTest extends AbstractInjectorTestCase
         // @codingStandardsIgnoreEnd
     }
 
-    public function emptyConfiguration()
+    /**
+     * @psalm-return array<string, array{0: string}>
+     */
+    public function emptyConfiguration(): array
     {
         // @codingStandardsIgnoreStart
         $baseContentsLongArray  = '<' . "?php\nreturn array(\n    'modules' => array(\n        'Application',\n    )\n);";
@@ -76,7 +88,10 @@ class DevelopmentConfigInjectorTest extends AbstractInjectorTestCase
         ];
     }
 
-    public function packagePopulatedInConfiguration()
+    /**
+     * @psalm-return array<string, array{0: string, 1: string}>
+     */
+    public function packagePopulatedInConfiguration(): array
     {
         // @codingStandardsIgnoreStart
         $baseContentsLongArray  = '<' . "?php\nreturn array(\n    'modules' => array(\n        'Application',\n    )\n);";

--- a/test/Injector/MezzioConfigInjectorTest.php
+++ b/test/Injector/MezzioConfigInjectorTest.php
@@ -25,12 +25,15 @@ class MezzioConfigInjectorTest extends AbstractInjectorTestCase
         MezzioConfigInjector::TYPE_CONFIG_PROVIDER,
     ];
 
-    public function convertToShortArraySyntax($contents)
+    public function convertToShortArraySyntax(string $contents): string
     {
         return preg_replace('/array\(([^)]+)\)/s', '[$1]', $contents);
     }
 
-    public function allowedTypes()
+    /**
+     * @psalm-return array<string, array{0: int, 1: bool}>
+     */
+    public function allowedTypes(): array
     {
         return [
             'config-provider' => [MezzioConfigInjector::TYPE_CONFIG_PROVIDER, true],
@@ -39,7 +42,10 @@ class MezzioConfigInjectorTest extends AbstractInjectorTestCase
         ];
     }
 
-    public function injectComponentProvider()
+    /**
+     * @psalm-return array<string, array{0: int, 1: string, 2: string}>
+     */
+    public function injectComponentProvider(): array
     {
         // @codingStandardsIgnoreStart
         $baseContentsFqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/legacy-mezzio-application-fqcn.config.php');
@@ -69,7 +75,10 @@ class MezzioConfigInjectorTest extends AbstractInjectorTestCase
         // @codingStandardsIgnoreEnd
     }
 
-    public function packageAlreadyRegisteredProvider()
+    /**
+     * @psalm-return array<string, array{0: string, 1: int}>
+     */
+    public function packageAlreadyRegisteredProvider(): array
     {
         // @codingStandardsIgnoreStart
         $fqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/legacy-mezzio-populated-fqcn.config.php');
@@ -91,7 +100,10 @@ class MezzioConfigInjectorTest extends AbstractInjectorTestCase
         // @codingStandardsIgnoreEnd
     }
 
-    public function emptyConfiguration()
+    /**
+     * @psalm-return array<string, array{0: string}>
+     */
+    public function emptyConfiguration(): array
     {
         // @codingStandardsIgnoreStart
         $fqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/legacy-mezzio-empty-fqcn.config.php');
@@ -113,7 +125,10 @@ class MezzioConfigInjectorTest extends AbstractInjectorTestCase
         ];
     }
 
-    public function packagePopulatedInConfiguration()
+    /**
+     * @psalm-return array<string, array{0: string, 1: string}>
+     */
+    public function packagePopulatedInConfiguration(): array
     {
         // @codingStandardsIgnoreStart
         $baseContentsFqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/legacy-mezzio-populated-fqcn.config.php');

--- a/test/Injector/ModulesConfigInjectorTest.php
+++ b/test/Injector/ModulesConfigInjectorTest.php
@@ -26,7 +26,10 @@ class ModulesConfigInjectorTest extends AbstractInjectorTestCase
         ModulesConfigInjector::TYPE_BEFORE_APPLICATION,
     ];
 
-    public function allowedTypes()
+    /**
+     * @psalm-return array<string, array{0: int, 1: bool}>
+     */
+    public function allowedTypes(): array
     {
         return [
             'config-provider'            => [ModulesConfigInjector::TYPE_CONFIG_PROVIDER, false],
@@ -37,7 +40,10 @@ class ModulesConfigInjectorTest extends AbstractInjectorTestCase
         ];
     }
 
-    public function injectComponentProvider()
+    /**
+     * @psalm-return array<string, array{0: int, 1: string, 2: string}>
+     */
+    public function injectComponentProvider(): array
     {
         // @codingStandardsIgnoreStart
         $baseContentsLongArray  = '<' . "?php\nreturn array(\n    'Application',\n);";
@@ -51,7 +57,10 @@ class ModulesConfigInjectorTest extends AbstractInjectorTestCase
         // @codingStandardsIgnoreEnd
     }
 
-    public function packageAlreadyRegisteredProvider()
+    /**
+     * @psalm-return array<string, array{0: string, 1: int}>
+     */
+    public function packageAlreadyRegisteredProvider(): array
     {
         // @codingStandardsIgnoreStart
         return [
@@ -63,7 +72,10 @@ class ModulesConfigInjectorTest extends AbstractInjectorTestCase
         // @codingStandardsIgnoreEnd
     }
 
-    public function emptyConfiguration()
+    /**
+     * @psalm-return array<string, array{0: string}>
+     */
+    public function emptyConfiguration(): array
     {
         // @codingStandardsIgnoreStart
         $baseContentsLongArray  = '<' . "?php\nreturn array(\n    'Application',\n);";
@@ -76,7 +88,10 @@ class ModulesConfigInjectorTest extends AbstractInjectorTestCase
         ];
     }
 
-    public function packagePopulatedInConfiguration()
+    /**
+     * @psalm-return array<string, array{0: string, 1: string}>
+     */
+    public function packagePopulatedInConfiguration(): array
     {
         // @codingStandardsIgnoreStart
         $baseContentsLongArray  = '<' . "?php\nreturn array(\n    'Application',\n);";

--- a/test/Injector/NoopInjectorTest.php
+++ b/test/Injector/NoopInjectorTest.php
@@ -23,20 +23,21 @@ class NoopInjectorTest extends TestCase
 
     /**
      * @dataProvider packageTypes
-     *
-     * @param string $type
      */
-    public function testWillRegisterAnyType($type)
+    public function testWillRegisterAnyType(int $type): void
     {
         $this->assertTrue($this->injector->registersType($type), 'NoopInjector does not register type ' . $type);
     }
 
-    public function testGetTypesAllowedReturnsNoTypes()
+    public function testGetTypesAllowedReturnsNoTypes(): void
     {
         $this->assertEquals([], $this->injector->getTypesAllowed());
     }
 
-    public function packageTypes()
+    /**
+     * @psalm-return array<string, array{0: int}>
+     */
+    public function packageTypes(): array
     {
         return [
             'config-provider' => [NoopInjector::TYPE_CONFIG_PROVIDER],
@@ -47,17 +48,15 @@ class NoopInjectorTest extends TestCase
 
     /**
      * @dataProvider packageTypes
-     *
-     * @param string $type
      */
-    public function testInjectIsANoop($type)
+    public function testInjectIsANoop(int $type): void
     {
         $injected = $this->injector->inject('Foo\Bar', $type);
 
         $this->assertFalse($injected);
     }
 
-    public function testRemoveIsANoop()
+    public function testRemoveIsANoop(): void
     {
         $removed = $this->injector->remove('Foo\Bar');
 


### PR DESCRIPTION
- Adds psalm.xml.dist file
- Adds psalm and psalm PHPUnit plugin as dev dependencies
- Adds "static-analysis" script
- Adds script to Travis configuration to run on PHP 7.4 latest build
- Incorporates auto-fixes and manual psalm annotations per initial reporting; most of the test is Prophecy related.

Have run all unit tests, CS checks, and psalm locally, and all come back green currently.

Fixes #13
