### PR TITLE
Prevent multiple injections of a component/module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#24](https://github.com/laminas/laminas-component-installer/pull/24) fixes an issue whereby a config file that contains multiple points of possible injection was having the component/module injected multiple times. It now will inject only at the first matching location. If you maintain such a configuration file and need injection to occur multiple times or at a location other than the first match, you will need to do so manually.
 
 ## 2.3.2 - 2020-10-27
 

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -12,6 +12,7 @@
         <ignoreFiles>
             <directory name="vendor"/>
             <directory name="test/TestAsset/"/>
+            <directory name="test/Injector/TestAsset/"/>
         </ignoreFiles>
     </projectFiles>
 

--- a/src/Injector/AbstractInjector.php
+++ b/src/Injector/AbstractInjector.php
@@ -199,7 +199,7 @@ abstract class AbstractInjector implements InjectorInterface
             $package
         );
 
-        $config = preg_replace($pattern, $replacement, $config);
+        $config = preg_replace($pattern, $replacement, $config, 1);
         file_put_contents($this->configFile, $config);
 
         return true;
@@ -238,7 +238,7 @@ abstract class AbstractInjector implements InjectorInterface
             $package
         );
 
-        $config = preg_replace($pattern, $replacement, $config);
+        $config = preg_replace($pattern, $replacement, $config, 1);
         file_put_contents($this->configFile, $config);
 
         return true;
@@ -293,7 +293,7 @@ abstract class AbstractInjector implements InjectorInterface
             $package
         );
 
-        $config = preg_replace($pattern, $replacement, $config);
+        $config = preg_replace($pattern, $replacement, $config, 1);
         file_put_contents($this->configFile, $config);
 
         return true;

--- a/test/Injector/ConfigAggregatorInjectorTest.php
+++ b/test/Injector/ConfigAggregatorInjectorTest.php
@@ -70,6 +70,9 @@ class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
         $expectedContentsImportShortArray            = $this->convertToShortArraySyntax($expectedContentsImportLongArray);
         $expectedContentsImportShortArrayAltIndent   = $this->convertToShortArraySyntax($expectedContentsImportLongArrayAltIndent);
 
+        $injectOnlyFirstOccurrenceInitial  = file_get_contents(__DIR__ . '/TestAsset/mezzio-with-postprocessor.config.php');
+        $injectOnlyFirstOccurrenceExpected = file_get_contents(__DIR__ . '/TestAsset/mezzio-with-postprocessor-post-injection.config.php');
+
         return [
             'fqcn-long-array'               => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsFqcnLongArray,               $expectedContentsFqcnLongArray],
             'global-long-array'             => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsGloballyQualifiedLongArray,  $expectedContentsGloballyQualifiedLongArray],
@@ -79,6 +82,8 @@ class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
             'global-short-array'            => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsGloballyQualifiedShortArray, $expectedContentsGloballyQualifiedShortArray],
             'import-short-array'            => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportShortArray,            $expectedContentsImportShortArray],
             'import-short-array-alt-indent' => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportShortArrayAltIndent,   $expectedContentsImportShortArrayAltIndent],
+            // see https://github.com/laminas/laminas-component-installer/issues/21
+            'inject-only-first-occurence'   => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $injectOnlyFirstOccurrenceInitial, $injectOnlyFirstOccurrenceExpected],
         ];
         // @codingStandardsIgnoreEnd
     }

--- a/test/Injector/TestAsset/mezzio-with-postprocessor-post-injection.config.php
+++ b/test/Injector/TestAsset/mezzio-with-postprocessor-post-injection.config.php
@@ -1,0 +1,22 @@
+<?php
+use Laminas\ConfigAggregatorParameters\LazyParameterPostProcessor;
+use Laminas\ConfigAggregator\ConfigAggregator;
+use Laminas\ConfigAggregator\PhpFileProvider;
+
+$aggregator = new ConfigAggregator(array(
+    \Foo\Bar::class,
+    \Laminas\Filter\ConfigProvider::class,
+    Application\ConfigProvider::class,
+), null, [
+    new LazyParameterPostProcessor(static function (): array {
+        return (new ConfigAggregator([
+            new PhpFileProvider(sprintf(
+                '%s/parameters{,*.}(,%s,local}.php',
+                __DIR__,
+                'someenv'
+            )),
+        ]))->getMergedConfig();
+    }),
+]);
+
+return $aggregator->getMergedConfig();

--- a/test/Injector/TestAsset/mezzio-with-postprocessor.config.php
+++ b/test/Injector/TestAsset/mezzio-with-postprocessor.config.php
@@ -1,0 +1,21 @@
+<?php
+use Laminas\ConfigAggregatorParameters\LazyParameterPostProcessor;
+use Laminas\ConfigAggregator\ConfigAggregator;
+use Laminas\ConfigAggregator\PhpFileProvider;
+
+$aggregator = new ConfigAggregator(array(
+    \Laminas\Filter\ConfigProvider::class,
+    Application\ConfigProvider::class,
+), null, [
+    new LazyParameterPostProcessor(static function (): array {
+        return (new ConfigAggregator([
+            new PhpFileProvider(sprintf(
+                '%s/parameters{,*.}(,%s,local}.php',
+                __DIR__,
+                'someenv'
+            )),
+        ]))->getMergedConfig();
+    }),
+]);
+
+return $aggregator->getMergedConfig();


### PR DESCRIPTION
In previous versions, it was possible to create configuration files that could potentially contain multiple injection locations.  We should, however, assume exactly one injection is intended, and that it is in the first position to be found.  `preg_replace`, by default, will inject for every match; an optional fourth argument, however, allows specifying an upper limit of how many replacements may be made.  I have set this to `1` throughout `AbstractInjector` at this time to prevent multiple injections from occurring.

If users have files that allow multiple injection, and need injection to occur at a location other than the first match, they will need to remove this plugin, and do so manually.

Fixes #21
