### PR TITLE
qa: remove prophecy usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "mikey179/vfsstream": "^1.6.7",
         "phpunit/phpunit": "^9.3",
         "psalm/plugin-phpunit": "^0.13.0",
-        "vimeo/psalm": "^4.2"
+        "vimeo/psalm": "^4.2",
+        "webmozart/assert": "^1.6"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
         "laminas/laminas-coding-standard": "~2.1.4",
         "malukenho/docheader": "^0.1.6",
         "mikey179/vfsstream": "^1.6.7",
-        "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.3",
         "psalm/plugin-phpunit": "^0.13.0",
         "vimeo/psalm": "^4.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e4f036dcb9c4b8c49403ee2a2963b411",
+    "content-hash": "e2466b7d82fa1581b174e31c55200d3a",
     "packages": [
         {
             "name": "laminas/laminas-zendframework-bridge",
@@ -1760,58 +1760,6 @@
                 "source": "https://github.com/phpspec/prophecy/tree/1.13.0"
             },
             "time": "2021-03-17T13:42:18+00:00"
-        },
-        {
-            "name": "phpspec/prophecy-phpunit",
-            "version": "v2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpspec/prophecy-phpunit.git",
-                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy-phpunit/zipball/2d7a9df55f257d2cba9b1d0c0963a54960657177",
-                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3 || ^8",
-                "phpspec/prophecy": "^1.3",
-                "phpunit/phpunit": "^9.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Prophecy\\PhpUnit\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Christophe Coevoet",
-                    "email": "stof@notk.org"
-                }
-            ],
-            "description": "Integrating the Prophecy mocking library in PHPUnit test cases",
-            "homepage": "http://phpspec.net",
-            "keywords": [
-                "phpunit",
-                "prophecy"
-            ],
-            "support": {
-                "issues": "https://github.com/phpspec/prophecy-phpunit/issues",
-                "source": "https://github.com/phpspec/prophecy-phpunit/tree/v2.0.1"
-            },
-            "time": "2020-07-09T08:33:42+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.6.4@97fe86c4e158b5a57c5150aa5055c38b5a809aab">
   <file src="src/Collection.php">
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction occurrences="1">
       <code>is_array($items)</code>
-      <code>null === $offset</code>
     </DocblockTypeContradiction>
     <MissingClosureParamType occurrences="9">
       <code>$filtered</code>
@@ -50,27 +49,21 @@
     </UnsafeInstantiation>
   </file>
   <file src="src/ComponentInstaller.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>is_callable($this-&gt;packageProviderFactory)</code>
-    </DocblockTypeContradiction>
-    <InvalidPropertyAssignmentValue occurrences="1"/>
     <InvalidScalarArgument occurrences="1">
       <code>$default</code>
     </InvalidScalarArgument>
-    <MissingClosureParamType occurrences="30">
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$dependencies-&gt;getArrayCopy()</code>
+    </LessSpecificReturnStatement>
+    <MissingClosureParamType occurrences="24">
       <code>$allowed</code>
       <code>$ask</code>
       <code>$configKey</code>
       <code>$configKey</code>
       <code>$configOption</code>
-      <code>$discoveredTypes</code>
       <code>$index</code>
       <code>$injector</code>
-      <code>$injector</code>
-      <code>$injectors</code>
       <code>$key</code>
-      <code>$module</code>
-      <code>$module</code>
       <code>$module</code>
       <code>$module</code>
       <code>$modules</code>
@@ -85,7 +78,6 @@
       <code>$type</code>
       <code>$type</code>
       <code>$type</code>
-      <code>$type</code>
       <code>$valid</code>
       <code>$value</code>
     </MissingClosureParamType>
@@ -96,77 +88,43 @@
       <code>function ($module) use ($options) {</code>
       <code>function ($modules, $configKey, $type) use ($extra, $supportedTypes) {</code>
     </MissingClosureReturnType>
-    <MixedArgument occurrences="23">
+    <MixedArgument occurrences="12">
       <code>$ask</code>
       <code>$ask</code>
       <code>$configKey</code>
       <code>$index</code>
       <code>$injector</code>
-      <code>$injector</code>
       <code>$item</code>
-      <code>$map</code>
       <code>$module</code>
-      <code>$module</code>
-      <code>$module</code>
-      <code>$module</code>
-      <code>$module</code>
-      <code>$name</code>
       <code>$option-&gt;getPromptText()</code>
-      <code>$package-&gt;getExtra()</code>
-      <code>$packageProviderDetection</code>
       <code>$packageType</code>
       <code>$packageTypes[$module]</code>
-      <code>$path</code>
       <code>$supportedTypes</code>
       <code>$value</code>
-      <code>$whitelist</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="4">
+    <MixedArgumentTypeCoercion occurrences="1">
       <code>$extra</code>
-      <code>$extra</code>
-      <code>$namespace</code>
-      <code>$type</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAssignment occurrences="4">
+    <MixedArrayAssignment occurrences="2">
       <code>$ask[]</code>
       <code>$ask[]</code>
-      <code>$discoveredTypes[$package]</code>
-      <code>$injectors[$module]</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="6">
-      <code>$dependencies[$module]</code>
-      <code>$discoveredTypes[$package]</code>
+    <MixedArrayOffset occurrences="1">
       <code>$extra[$configKey]</code>
-      <code>$packageTypes[$module]</code>
-      <code>$packageTypes[$module]</code>
-      <code>$packageTypes[$type]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="13">
+    <MixedAssignment occurrences="4">
       <code>$ask</code>
       <code>$injector</code>
-      <code>$map</code>
-      <code>$name</code>
-      <code>$package</code>
-      <code>$package</code>
-      <code>$packageProviderDetection</code>
       <code>$packageType</code>
-      <code>$path</code>
-      <code>$paths</code>
       <code>$supportedTypes</code>
-      <code>$this-&gt;packageProviderFactory</code>
-      <code>$whitelist</code>
     </MixedAssignment>
-    <MixedFunctionCall occurrences="1">
-      <code>($this-&gt;packageProviderFactory)()</code>
-    </MixedFunctionCall>
     <MixedInferredReturnType occurrences="4">
       <code>Collection</code>
       <code>Collection</code>
       <code>InjectorInterface</code>
       <code>bool</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="20">
-      <code>getExtra</code>
+    <MixedMethodCall occurrences="16">
       <code>getInjector</code>
       <code>getInjector</code>
       <code>getInjector</code>
@@ -174,15 +132,12 @@
       <code>getInjector</code>
       <code>getInjector</code>
       <code>getInjector</code>
-      <code>getName</code>
       <code>getPromptText</code>
       <code>getTypesAllowed</code>
       <code>isRegistered</code>
       <code>merge</code>
       <code>merge</code>
       <code>registersType</code>
-      <code>setApplicationModules</code>
-      <code>setModuleDependencies</code>
       <code>toArray</code>
       <code>unique</code>
       <code>unique</code>
@@ -191,6 +146,9 @@
       <code>$options[1]-&gt;getInjector()</code>
       <code>isset($options[2]) ? $options[2]-&gt;getInjector() : $options[1]-&gt;getInjector()</code>
     </MixedReturnStatement>
+    <MoreSpecificReturnType occurrences="1">
+      <code>array&lt;non-empty-string,list&lt;non-empty-string&gt;&gt;</code>
+    </MoreSpecificReturnType>
     <PossiblyNullArgument occurrences="1">
       <code>$this-&gt;io-&gt;ask(implode($ask), 'y')</code>
     </PossiblyNullArgument>
@@ -205,18 +163,11 @@
       <code>is_string($projectRoot)</code>
       <code>is_string($this-&gt;projectRoot)</code>
     </RedundantConditionGivenDocblockType>
-    <UndefinedInterfaceMethod occurrences="1">
-      <code>getPackage</code>
-    </UndefinedInterfaceMethod>
   </file>
   <file src="src/ConfigDiscovery.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>is_array($injectorClass)</code>
-    </DocblockTypeContradiction>
-    <InvalidPropertyAssignmentValue occurrences="2"/>
-    <InvalidStringClass occurrences="1">
-      <code>new $injectorClass($projectRoot)</code>
-    </InvalidStringClass>
+    <InvalidArgument occurrences="1">
+      <code>$injectorClass</code>
+    </InvalidArgument>
     <MissingClosureParamType occurrences="9">
       <code>$discovery</code>
       <code>$discovery</code>
@@ -244,9 +195,6 @@
       <code>new $discoveryClass($projectRoot)</code>
       <code>registersType</code>
     </MixedMethodCall>
-    <NullArgument occurrences="1">
-      <code>$discovered</code>
-    </NullArgument>
   </file>
   <file src="src/ConfigDiscovery/AbstractDiscovery.php">
     <PossiblyNullArgument occurrences="1">
@@ -394,277 +342,26 @@
     </UndefinedMethod>
   </file>
   <file src="test/ComponentInstallerTest.php">
-    <ImplicitToStringCast occurrences="47">
-      <code>Argument::any()</code>
-      <code>Argument::that($askValidator)</code>
-      <code>Argument::that($askValidator)</code>
-    </ImplicitToStringCast>
-    <InvalidArgument occurrences="4">
-      <code>Argument::exact($package-&gt;reveal())</code>
-      <code>Argument::exact($package-&gt;reveal())</code>
-      <code>Argument::that([$package, 'reveal'])</code>
-      <code>Argument::type(RootPackageRepository::class)</code>
-    </InvalidArgument>
-    <InvalidScalarArgument occurrences="31">
-      <code>1</code>
-      <code>1</code>
-      <code>1</code>
-      <code>1</code>
-      <code>1</code>
-      <code>1</code>
-      <code>1</code>
-      <code>1</code>
-      <code>1</code>
-      <code>1</code>
-      <code>1</code>
-      <code>1</code>
-      <code>1</code>
-      <code>1</code>
-    </InvalidScalarArgument>
-    <MissingClosureParamType occurrences="45">
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-    </MissingClosureParamType>
     <MissingParamType occurrences="1">
       <code>$argument</code>
     </MissingParamType>
-    <MixedArgument occurrences="40">
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
-      <code>$argument</code>
+    <MixedArgument occurrences="2">
       <code>$configName</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
       <code>$pathToModule</code>
-      <code>$this-&gt;composer-&gt;reveal()</code>
-      <code>$this-&gt;io-&gt;reveal()</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>[$package, 'reveal']</code>
-    </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="8">
-      <code>$config['modules']</code>
-      <code>$config['modules']</code>
-      <code>$config['modules']</code>
-      <code>$config['modules']</code>
-      <code>$config['modules']</code>
-      <code>$config['modules']</code>
-      <code>$config['modules']</code>
-      <code>$config['modules']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="19">
-      <code>$config</code>
-      <code>$config</code>
-      <code>$config</code>
-      <code>$config</code>
-      <code>$config</code>
-      <code>$config</code>
-      <code>$config</code>
+    <MixedAssignment occurrences="4">
       <code>$config</code>
       <code>$configName</code>
       <code>$dependencies</code>
       <code>$dependencies</code>
-      <code>$modules</code>
-      <code>$modules</code>
-      <code>$modules</code>
-      <code>$modules</code>
-      <code>$modules</code>
-      <code>$modules</code>
-      <code>$modules</code>
-      <code>$modules</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="1">
       <code>array</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="90">
-      <code>shouldBeCalledTimes</code>
-      <code>shouldNotBeCalled</code>
-      <code>will</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-    </MixedMethodCall>
-    <PossiblyInvalidMethodCall occurrences="3">
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-    </PossiblyInvalidMethodCall>
-    <PossiblyUndefinedMethod occurrences="2">
-      <code>reveal</code>
-      <code>reveal</code>
-    </PossiblyUndefinedMethod>
     <PossiblyUndefinedVariable occurrences="2">
       <code>$autoload</code>
       <code>$pathToModule</code>
     </PossiblyUndefinedVariable>
-    <UnresolvableInclude occurrences="8">
-      <code>include vfsStream::url('project/config/application.config.php')</code>
-      <code>include vfsStream::url('project/config/application.config.php')</code>
-      <code>include vfsStream::url('project/config/application.config.php')</code>
-      <code>include vfsStream::url('project/config/application.config.php')</code>
-      <code>include vfsStream::url('project/config/application.config.php')</code>
-      <code>include vfsStream::url('project/config/development.config.php')</code>
-      <code>include vfsStream::url('project/config/modules.config.php')</code>
-      <code>include vfsStream::url('project/config/modules.config.php')</code>
-    </UnresolvableInclude>
   </file>
   <file src="test/ConfigDiscoveryTest.php">
     <InternalClass occurrences="6">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.6.4@97fe86c4e158b5a57c5150aa5055c38b5a809aab">
   <file src="src/Collection.php">
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction occurrences="1">
       <code>is_array($items)</code>
-      <code>null === $offset</code>
     </DocblockTypeContradiction>
     <MissingClosureParamType occurrences="9">
       <code>$filtered</code>
@@ -50,27 +49,18 @@
     </UnsafeInstantiation>
   </file>
   <file src="src/ComponentInstaller.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>is_callable($this-&gt;packageProviderFactory)</code>
-    </DocblockTypeContradiction>
-    <InvalidPropertyAssignmentValue occurrences="1"/>
     <InvalidScalarArgument occurrences="1">
       <code>$default</code>
     </InvalidScalarArgument>
-    <MissingClosureParamType occurrences="30">
+    <MissingClosureParamType occurrences="24">
       <code>$allowed</code>
       <code>$ask</code>
       <code>$configKey</code>
       <code>$configKey</code>
       <code>$configOption</code>
-      <code>$discoveredTypes</code>
       <code>$index</code>
       <code>$injector</code>
-      <code>$injector</code>
-      <code>$injectors</code>
       <code>$key</code>
-      <code>$module</code>
-      <code>$module</code>
       <code>$module</code>
       <code>$module</code>
       <code>$modules</code>
@@ -85,7 +75,6 @@
       <code>$type</code>
       <code>$type</code>
       <code>$type</code>
-      <code>$type</code>
       <code>$valid</code>
       <code>$value</code>
     </MissingClosureParamType>
@@ -96,77 +85,44 @@
       <code>function ($module) use ($options) {</code>
       <code>function ($modules, $configKey, $type) use ($extra, $supportedTypes) {</code>
     </MissingClosureReturnType>
-    <MixedArgument occurrences="23">
+    <MixedArgument occurrences="12">
       <code>$ask</code>
       <code>$ask</code>
       <code>$configKey</code>
       <code>$index</code>
       <code>$injector</code>
-      <code>$injector</code>
       <code>$item</code>
-      <code>$map</code>
       <code>$module</code>
-      <code>$module</code>
-      <code>$module</code>
-      <code>$module</code>
-      <code>$module</code>
-      <code>$name</code>
       <code>$option-&gt;getPromptText()</code>
-      <code>$package-&gt;getExtra()</code>
-      <code>$packageProviderDetection</code>
       <code>$packageType</code>
       <code>$packageTypes[$module]</code>
-      <code>$path</code>
       <code>$supportedTypes</code>
       <code>$value</code>
-      <code>$whitelist</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="4">
+    <MixedArgumentTypeCoercion occurrences="1">
       <code>$extra</code>
-      <code>$extra</code>
-      <code>$namespace</code>
-      <code>$type</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAssignment occurrences="4">
+    <MixedArrayAssignment occurrences="2">
       <code>$ask[]</code>
       <code>$ask[]</code>
-      <code>$discoveredTypes[$package]</code>
-      <code>$injectors[$module]</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="6">
-      <code>$dependencies[$module]</code>
-      <code>$discoveredTypes[$package]</code>
+    <MixedArrayOffset occurrences="1">
       <code>$extra[$configKey]</code>
-      <code>$packageTypes[$module]</code>
-      <code>$packageTypes[$module]</code>
-      <code>$packageTypes[$type]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="13">
+    <MixedAssignment occurrences="4">
       <code>$ask</code>
       <code>$injector</code>
-      <code>$map</code>
-      <code>$name</code>
-      <code>$package</code>
-      <code>$package</code>
-      <code>$packageProviderDetection</code>
       <code>$packageType</code>
-      <code>$path</code>
-      <code>$paths</code>
       <code>$supportedTypes</code>
-      <code>$this-&gt;packageProviderFactory</code>
-      <code>$whitelist</code>
     </MixedAssignment>
-    <MixedFunctionCall occurrences="1">
-      <code>($this-&gt;packageProviderFactory)()</code>
-    </MixedFunctionCall>
     <MixedInferredReturnType occurrences="4">
       <code>Collection</code>
       <code>Collection</code>
       <code>InjectorInterface</code>
       <code>bool</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="20">
-      <code>getExtra</code>
+    <MixedMethodCall occurrences="17">
+      <code>each</code>
       <code>getInjector</code>
       <code>getInjector</code>
       <code>getInjector</code>
@@ -174,15 +130,12 @@
       <code>getInjector</code>
       <code>getInjector</code>
       <code>getInjector</code>
-      <code>getName</code>
       <code>getPromptText</code>
       <code>getTypesAllowed</code>
       <code>isRegistered</code>
       <code>merge</code>
       <code>merge</code>
       <code>registersType</code>
-      <code>setApplicationModules</code>
-      <code>setModuleDependencies</code>
       <code>toArray</code>
       <code>unique</code>
       <code>unique</code>
@@ -205,18 +158,8 @@
       <code>is_string($projectRoot)</code>
       <code>is_string($this-&gt;projectRoot)</code>
     </RedundantConditionGivenDocblockType>
-    <UndefinedInterfaceMethod occurrences="1">
-      <code>getPackage</code>
-    </UndefinedInterfaceMethod>
   </file>
   <file src="src/ConfigDiscovery.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>is_array($injectorClass)</code>
-    </DocblockTypeContradiction>
-    <InvalidPropertyAssignmentValue occurrences="2"/>
-    <InvalidStringClass occurrences="1">
-      <code>new $injectorClass($projectRoot)</code>
-    </InvalidStringClass>
     <MissingClosureParamType occurrences="9">
       <code>$discovery</code>
       <code>$discovery</code>
@@ -244,9 +187,6 @@
       <code>new $discoveryClass($projectRoot)</code>
       <code>registersType</code>
     </MixedMethodCall>
-    <NullArgument occurrences="1">
-      <code>$discovered</code>
-    </NullArgument>
   </file>
   <file src="src/ConfigDiscovery/AbstractDiscovery.php">
     <PossiblyNullArgument occurrences="1">
@@ -468,7 +408,7 @@
       <code>$argument</code>
       <code>$argument</code>
     </MissingClosureParamType>
-    <MixedArgument occurrences="40">
+    <MixedArgument occurrences="42">
       <code>$argument</code>
       <code>$argument</code>
       <code>$argument</code>
@@ -490,178 +430,24 @@
       <code>$argument</code>
       <code>$argument</code>
       <code>$configName</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
-      <code>$event-&gt;reveal()</code>
       <code>$pathToModule</code>
-      <code>$this-&gt;composer-&gt;reveal()</code>
-      <code>$this-&gt;io-&gt;reveal()</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>[$package, 'reveal']</code>
-    </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="8">
-      <code>$config['modules']</code>
-      <code>$config['modules']</code>
-      <code>$config['modules']</code>
-      <code>$config['modules']</code>
-      <code>$config['modules']</code>
-      <code>$config['modules']</code>
-      <code>$config['modules']</code>
-      <code>$config['modules']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="19">
-      <code>$config</code>
-      <code>$config</code>
-      <code>$config</code>
-      <code>$config</code>
-      <code>$config</code>
-      <code>$config</code>
-      <code>$config</code>
+    <MissingParamType occurrences="1">
+      <code>$argument</code>
+    </MissingParamType>
+    <MixedAssignment occurrences="4">
       <code>$config</code>
       <code>$configName</code>
       <code>$dependencies</code>
       <code>$dependencies</code>
-      <code>$modules</code>
-      <code>$modules</code>
-      <code>$modules</code>
-      <code>$modules</code>
-      <code>$modules</code>
-      <code>$modules</code>
-      <code>$modules</code>
-      <code>$modules</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="1">
       <code>array</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="90">
-      <code>shouldBeCalledTimes</code>
-      <code>shouldNotBeCalled</code>
-      <code>will</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-    </MixedMethodCall>
-    <PossiblyInvalidMethodCall occurrences="3">
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-    </PossiblyInvalidMethodCall>
-    <PossiblyUndefinedMethod occurrences="2">
-      <code>reveal</code>
-      <code>reveal</code>
-    </PossiblyUndefinedMethod>
     <PossiblyUndefinedVariable occurrences="2">
       <code>$autoload</code>
       <code>$pathToModule</code>
     </PossiblyUndefinedVariable>
-    <UnresolvableInclude occurrences="8">
-      <code>include vfsStream::url('project/config/application.config.php')</code>
-      <code>include vfsStream::url('project/config/application.config.php')</code>
-      <code>include vfsStream::url('project/config/application.config.php')</code>
-      <code>include vfsStream::url('project/config/application.config.php')</code>
-      <code>include vfsStream::url('project/config/application.config.php')</code>
-      <code>include vfsStream::url('project/config/development.config.php')</code>
-      <code>include vfsStream::url('project/config/modules.config.php')</code>
-      <code>include vfsStream::url('project/config/modules.config.php')</code>
-    </UnresolvableInclude>
   </file>
   <file src="test/ConfigDiscoveryTest.php">
     <InternalClass occurrences="6">
@@ -691,5 +477,9 @@
       <code>$this-&gt;discovery</code>
       <code>ConfigDiscovery\</code>
     </UndefinedDocblockClass>
+  </file>
+  <file src="test/Injector/AbstractInjectorTestCase.php">
+    <InvalidStringClass occurrences="1"/>
+    <PropertyTypeCoercion occurrences="1"/>
   </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.6.4@97fe86c4e158b5a57c5150aa5055c38b5a809aab">
   <file src="src/Collection.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction occurrences="2">
       <code>is_array($items)</code>
+      <code>null === $offset</code>
     </DocblockTypeContradiction>
     <MissingClosureParamType occurrences="9">
       <code>$filtered</code>
@@ -49,18 +50,27 @@
     </UnsafeInstantiation>
   </file>
   <file src="src/ComponentInstaller.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>is_callable($this-&gt;packageProviderFactory)</code>
+    </DocblockTypeContradiction>
+    <InvalidPropertyAssignmentValue occurrences="1"/>
     <InvalidScalarArgument occurrences="1">
       <code>$default</code>
     </InvalidScalarArgument>
-    <MissingClosureParamType occurrences="24">
+    <MissingClosureParamType occurrences="30">
       <code>$allowed</code>
       <code>$ask</code>
       <code>$configKey</code>
       <code>$configKey</code>
       <code>$configOption</code>
+      <code>$discoveredTypes</code>
       <code>$index</code>
       <code>$injector</code>
+      <code>$injector</code>
+      <code>$injectors</code>
       <code>$key</code>
+      <code>$module</code>
+      <code>$module</code>
       <code>$module</code>
       <code>$module</code>
       <code>$modules</code>
@@ -75,6 +85,7 @@
       <code>$type</code>
       <code>$type</code>
       <code>$type</code>
+      <code>$type</code>
       <code>$valid</code>
       <code>$value</code>
     </MissingClosureParamType>
@@ -85,44 +96,77 @@
       <code>function ($module) use ($options) {</code>
       <code>function ($modules, $configKey, $type) use ($extra, $supportedTypes) {</code>
     </MissingClosureReturnType>
-    <MixedArgument occurrences="12">
+    <MixedArgument occurrences="23">
       <code>$ask</code>
       <code>$ask</code>
       <code>$configKey</code>
       <code>$index</code>
       <code>$injector</code>
+      <code>$injector</code>
       <code>$item</code>
+      <code>$map</code>
       <code>$module</code>
+      <code>$module</code>
+      <code>$module</code>
+      <code>$module</code>
+      <code>$module</code>
+      <code>$name</code>
       <code>$option-&gt;getPromptText()</code>
+      <code>$package-&gt;getExtra()</code>
+      <code>$packageProviderDetection</code>
       <code>$packageType</code>
       <code>$packageTypes[$module]</code>
+      <code>$path</code>
       <code>$supportedTypes</code>
       <code>$value</code>
+      <code>$whitelist</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion occurrences="4">
       <code>$extra</code>
+      <code>$extra</code>
+      <code>$namespace</code>
+      <code>$type</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAssignment occurrences="2">
+    <MixedArrayAssignment occurrences="4">
       <code>$ask[]</code>
       <code>$ask[]</code>
+      <code>$discoveredTypes[$package]</code>
+      <code>$injectors[$module]</code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="1">
+    <MixedArrayOffset occurrences="6">
+      <code>$dependencies[$module]</code>
+      <code>$discoveredTypes[$package]</code>
       <code>$extra[$configKey]</code>
+      <code>$packageTypes[$module]</code>
+      <code>$packageTypes[$module]</code>
+      <code>$packageTypes[$type]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="13">
       <code>$ask</code>
       <code>$injector</code>
+      <code>$map</code>
+      <code>$name</code>
+      <code>$package</code>
+      <code>$package</code>
+      <code>$packageProviderDetection</code>
       <code>$packageType</code>
+      <code>$path</code>
+      <code>$paths</code>
       <code>$supportedTypes</code>
+      <code>$this-&gt;packageProviderFactory</code>
+      <code>$whitelist</code>
     </MixedAssignment>
+    <MixedFunctionCall occurrences="1">
+      <code>($this-&gt;packageProviderFactory)()</code>
+    </MixedFunctionCall>
     <MixedInferredReturnType occurrences="4">
       <code>Collection</code>
       <code>Collection</code>
       <code>InjectorInterface</code>
       <code>bool</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="17">
-      <code>each</code>
+    <MixedMethodCall occurrences="20">
+      <code>getExtra</code>
       <code>getInjector</code>
       <code>getInjector</code>
       <code>getInjector</code>
@@ -130,12 +174,15 @@
       <code>getInjector</code>
       <code>getInjector</code>
       <code>getInjector</code>
+      <code>getName</code>
       <code>getPromptText</code>
       <code>getTypesAllowed</code>
       <code>isRegistered</code>
       <code>merge</code>
       <code>merge</code>
       <code>registersType</code>
+      <code>setApplicationModules</code>
+      <code>setModuleDependencies</code>
       <code>toArray</code>
       <code>unique</code>
       <code>unique</code>
@@ -158,8 +205,18 @@
       <code>is_string($projectRoot)</code>
       <code>is_string($this-&gt;projectRoot)</code>
     </RedundantConditionGivenDocblockType>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>getPackage</code>
+    </UndefinedInterfaceMethod>
   </file>
   <file src="src/ConfigDiscovery.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>is_array($injectorClass)</code>
+    </DocblockTypeContradiction>
+    <InvalidPropertyAssignmentValue occurrences="2"/>
+    <InvalidStringClass occurrences="1">
+      <code>new $injectorClass($projectRoot)</code>
+    </InvalidStringClass>
     <MissingClosureParamType occurrences="9">
       <code>$discovery</code>
       <code>$discovery</code>
@@ -187,6 +244,9 @@
       <code>new $discoveryClass($projectRoot)</code>
       <code>registersType</code>
     </MixedMethodCall>
+    <NullArgument occurrences="1">
+      <code>$discovered</code>
+    </NullArgument>
   </file>
   <file src="src/ConfigDiscovery/AbstractDiscovery.php">
     <PossiblyNullArgument occurrences="1">
@@ -408,7 +468,10 @@
       <code>$argument</code>
       <code>$argument</code>
     </MissingClosureParamType>
-    <MixedArgument occurrences="42">
+    <MissingParamType occurrences="1">
+      <code>$argument</code>
+    </MissingParamType>
+    <MixedArgument occurrences="40">
       <code>$argument</code>
       <code>$argument</code>
       <code>$argument</code>
@@ -430,24 +493,178 @@
       <code>$argument</code>
       <code>$argument</code>
       <code>$configName</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
+      <code>$event-&gt;reveal()</code>
       <code>$pathToModule</code>
+      <code>$this-&gt;composer-&gt;reveal()</code>
+      <code>$this-&gt;io-&gt;reveal()</code>
     </MixedArgument>
-    <MissingParamType occurrences="1">
-      <code>$argument</code>
-    </MissingParamType>
-    <MixedAssignment occurrences="4">
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>[$package, 'reveal']</code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAccess occurrences="8">
+      <code>$config['modules']</code>
+      <code>$config['modules']</code>
+      <code>$config['modules']</code>
+      <code>$config['modules']</code>
+      <code>$config['modules']</code>
+      <code>$config['modules']</code>
+      <code>$config['modules']</code>
+      <code>$config['modules']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="19">
+      <code>$config</code>
+      <code>$config</code>
+      <code>$config</code>
+      <code>$config</code>
+      <code>$config</code>
+      <code>$config</code>
+      <code>$config</code>
       <code>$config</code>
       <code>$configName</code>
       <code>$dependencies</code>
       <code>$dependencies</code>
+      <code>$modules</code>
+      <code>$modules</code>
+      <code>$modules</code>
+      <code>$modules</code>
+      <code>$modules</code>
+      <code>$modules</code>
+      <code>$modules</code>
+      <code>$modules</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="1">
       <code>array</code>
     </MixedInferredReturnType>
+    <MixedMethodCall occurrences="90">
+      <code>shouldBeCalledTimes</code>
+      <code>shouldNotBeCalled</code>
+      <code>will</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyInvalidMethodCall occurrences="3">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="2">
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
     <PossiblyUndefinedVariable occurrences="2">
       <code>$autoload</code>
       <code>$pathToModule</code>
     </PossiblyUndefinedVariable>
+    <UnresolvableInclude occurrences="8">
+      <code>include vfsStream::url('project/config/application.config.php')</code>
+      <code>include vfsStream::url('project/config/application.config.php')</code>
+      <code>include vfsStream::url('project/config/application.config.php')</code>
+      <code>include vfsStream::url('project/config/application.config.php')</code>
+      <code>include vfsStream::url('project/config/application.config.php')</code>
+      <code>include vfsStream::url('project/config/development.config.php')</code>
+      <code>include vfsStream::url('project/config/modules.config.php')</code>
+      <code>include vfsStream::url('project/config/modules.config.php')</code>
+    </UnresolvableInclude>
   </file>
   <file src="test/ConfigDiscoveryTest.php">
     <InternalClass occurrences="6">

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -17,6 +17,12 @@
     </projectFiles>
 
     <issueHandlers>
+        <InternalClass>
+            <errorLevel type="suppress">
+                <referencedClass name="Laminas\ComponentInstaller\Collection"/>
+            </errorLevel>
+        </InternalClass>
+
         <InternalMethod>
             <errorLevel type="suppress">
                 <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -219,7 +219,7 @@ class Collection implements
      *
      * If $offset is null, pushes the item onto the stack.
      *
-     * @param string|int $offset
+     * @param string|int|null $offset
      * @param mixed $value
      * @return void
      */

--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -29,7 +29,9 @@ use function array_filter;
 use function array_flip;
 use function array_keys;
 use function array_map;
+use function array_merge;
 use function array_unshift;
+use function array_values;
 use function assert;
 use function explode;
 use function file_exists;
@@ -37,7 +39,6 @@ use function file_get_contents;
 use function implode;
 use function in_array;
 use function is_array;
-use function is_callable;
 use function is_dir;
 use function is_numeric;
 use function is_string;
@@ -122,14 +123,10 @@ class ComponentInstaller implements
      */
     private $projectRoot;
 
-    /**
-     * @var Closure():PackageProviderDetectionFactory
-     */
+    /** @var Closure():PackageProviderDetectionFactory */
     private $packageProviderFactory;
 
-    /**
-     * @var Collection|null
-     */
+    /** @var Collection|null */
     private $discovered;
 
     /**
@@ -231,16 +228,13 @@ class ComponentInstaller implements
      *
      * These dependencies are used later
      *
-     * @param PackageInterface $package
-     *
-     * @return array
-     * @psalm-return array<non-empty-string,list<non-empty-string>>
      * @see \Laminas\ComponentInstaller\Injector\AbstractInjector::injectAfterDependencies
      *      to add component in a correct order on the module list - after dependencies.
      *
      * It works with PSR-0, PSR-4, 'classmap' and 'files' composer autoloading.
      *
      * @return array
+     * @psalm-return array<non-empty-string,list<non-empty-string>>
      */
     private function loadModuleClassesDependencies(PackageInterface $package)
     {
@@ -339,6 +333,7 @@ class ComponentInstaller implements
 
         /**
          * supports legacy "extra.zf" configuration
+         *
          * @var array<string,mixed> $deprecatedConfiguration
          */
         $deprecatedConfiguration = isset($extra['zf']) && is_array($extra['zf'])
@@ -916,7 +911,7 @@ class ComponentInstaller implements
         PackageInterface $package
     ): void {
         $packageTypes = $this->discoverPackageTypes($extra);
-        $options = (new ConfigDiscovery())
+        $options      = (new ConfigDiscovery())
             ->getAvailableConfigOptions($packageTypes, $this->projectRoot);
 
         if ($options->isEmpty()) {
@@ -927,9 +922,9 @@ class ComponentInstaller implements
         $packageProvider = ($this->packageProviderFactory)();
 
         $packageProviderDetection = $packageProvider->detect($event, $name);
-        $requireDev = $this->isADevDependency($packageProviderDetection, $package);
-        $dependencies = $this->loadModuleClassesDependencies($package);
-        $applicationModules = $this->findApplicationModules();
+        $requireDev               = $this->isADevDependency($packageProviderDetection, $package);
+        $dependencies             = $this->loadModuleClassesDependencies($package);
+        $applicationModules       = $this->findApplicationModules();
 
         $modules = $this->marshalInstallableModules($extra, $options)
             // Create injectors
@@ -940,10 +935,10 @@ class ComponentInstaller implements
                     // Get extra from root package
                     /** @var array<string,mixed> $rootPackageExtra */
                     $rootPackageExtra = $this->composer->getPackage()->getExtra();
-                    $rootExtra = $this->getExtraMetadata($rootPackageExtra);
-                    $whitelist = $rootExtra['component-whitelist'] ?? [];
+                    $rootExtra        = $this->getExtraMetadata($rootPackageExtra);
+                    $whitelist        = $rootExtra['component-whitelist'] ?? [];
                     assert(is_array($whitelist));
-                    $packageType = $packageTypes[$module];
+                    $packageType        = $packageTypes[$module];
                     $injectors[$module] = $this->promptForConfigOption(
                         $module,
                         $options,

--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -934,6 +934,7 @@ class ComponentInstaller implements
         $modules = $this->marshalInstallableModules($extra, $options)
             // Create injectors
             ->reduce(
+                // @codingStandardsIgnoreStart
                 function (Collection $injectors, string $module) use ($options, $packageTypes, $name, $requireDev): Collection {
                     // @codingStandardsIgnoreEnd
                     // Get extra from root package
@@ -961,17 +962,17 @@ class ComponentInstaller implements
 
         // Inject modules into configuration
         $modules->each(function (
-                InjectorInterface $injector,
-                string $module
-            ) use (
-                $name,
-                $packageTypes,
-                $applicationModules,
-                $dependencies
-            ) {
-                if (isset($dependencies[$module])) {
-                    $injector->setModuleDependencies($dependencies[$module]);
-                }
+            InjectorInterface $injector,
+            string $module
+        ) use (
+            $name,
+            $packageTypes,
+            $applicationModules,
+            $dependencies
+        ) {
+            if (isset($dependencies[$module])) {
+                $injector->setModuleDependencies($dependencies[$module]);
+            }
 
                 $injector->setApplicationModules($applicationModules);
                 $this->injectModuleIntoConfig(
@@ -980,7 +981,7 @@ class ComponentInstaller implements
                     $injector,
                     $packageTypes[$module]
                 );
-            });
+        });
     }
 
     /**

--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -756,8 +756,13 @@ class ComponentInstaller implements
      * @psalm-param list<string> $paths
      * @psalm-param ArrayObject<non-empty-string,list<string>> $dependencies
      */
-    private function mapNamespacePaths(array $paths, $namespace, string $type, ArrayObject $dependencies, string $packagePath): void
-    {
+    private function mapNamespacePaths(
+        array $paths,
+        $namespace,
+        string $type,
+        ArrayObject $dependencies,
+        string $packagePath
+    ): void {
         foreach ($paths as $path) {
             $this->mapPath($path, $namespace, $type, $dependencies, $packagePath);
         }
@@ -921,7 +926,9 @@ class ComponentInstaller implements
 
         $this->marshalInstallableModules($extra, $options)
             // Create injectors
+            // @codingStandardsIgnoreStart
             ->reduce(function (Collection $injectors, string $module) use ($options, $packageTypes, $name, $requireDev) {
+                // @codingStandardsIgnoreEnd
                 // Get extra from root package
                 /** @var array<string,mixed> $rootPackageExtra */
                 $rootPackageExtra = $this->composer->getPackage()->getExtra();

--- a/src/ConfigDiscovery.php
+++ b/src/ConfigDiscovery.php
@@ -10,8 +10,11 @@ namespace Laminas\ComponentInstaller;
 
 use Laminas\ComponentInstaller\ConfigDiscovery\DiscoveryInterface;
 use Laminas\ComponentInstaller\Injector\InjectorInterface;
+
+use function assert;
 use function class_exists;
 use function is_array;
+use function is_string;
 
 class ConfigDiscovery
 {

--- a/src/Injector/ConditionalDiscoveryTrait.php
+++ b/src/Injector/ConditionalDiscoveryTrait.php
@@ -21,7 +21,6 @@ trait ConditionalDiscoveryTrait
      * @param string $package Package to inject into configuration.
      * @param int $type One of the TYPE_* constants.
      * @return bool
-     * @throws Exception\RuntimeException
      */
     public function inject($package, $type)
     {
@@ -38,7 +37,6 @@ trait ConditionalDiscoveryTrait
      *
      * @param string $package Package to remove.
      * @return bool
-     * @throws Exception\RuntimeException
      */
     public function remove($package)
     {

--- a/src/Injector/ConditionalDiscoveryTrait.php
+++ b/src/Injector/ConditionalDiscoveryTrait.php
@@ -8,8 +8,6 @@
 
 namespace Laminas\ComponentInstaller\Injector;
 
-use Laminas\ComponentInstaller\Exception;
-
 use function str_replace;
 
 trait ConditionalDiscoveryTrait

--- a/test/AbstractQuestionAssertion.php
+++ b/test/AbstractQuestionAssertion.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * @see       https://github.com/laminas/laminas-component-installer for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-component-installer/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-component-installer/blob/master/LICENSE.md New BSD License
+ */
+
 declare(strict_types=1);
 
 namespace LaminasTest\ComponentInstaller;

--- a/test/AbstractQuestionAssertion.php
+++ b/test/AbstractQuestionAssertion.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace LaminasTest\ComponentInstaller;
+
+use function strpos;
+
+/**
+ * @psalm-immutable
+ */
+abstract class AbstractQuestionAssertion
+{
+    /**
+     * @var string
+     * @psalm-var non-empty-string
+     */
+    public $expectedQuestion;
+
+    /**
+     * @var mixed
+     * @psalm-var scalar
+     */
+    public $expectedAnswer;
+
+    /**
+     * @psalm-param non-empty-string $expectedQuestion
+     * @psalm-param scalar           $expectedAnswer
+     */
+    protected function __construct(string $expectedQuestion, $expectedAnswer)
+    {
+        $this->expectedQuestion = $expectedQuestion;
+        $this->expectedAnswer = $expectedAnswer;
+    }
+
+    /**
+     * @return Closure(string):bool
+     */
+    final public function assertion(): callable
+    {
+        return function (string $param): bool {
+            return $this->assertQuestionMatchesExpectation($param);
+        };
+    }
+
+    /**
+     * @param string  $argument
+     */
+    private function assertQuestionMatchesExpectation(string $argument): bool
+    {
+        return strpos($argument, $this->expectedQuestion) !== false;
+    }
+}

--- a/test/AbstractQuestionAssertion.php
+++ b/test/AbstractQuestionAssertion.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace LaminasTest\ComponentInstaller;
@@ -29,7 +30,7 @@ abstract class AbstractQuestionAssertion
     protected function __construct(string $expectedQuestion, $expectedAnswer)
     {
         $this->expectedQuestion = $expectedQuestion;
-        $this->expectedAnswer = $expectedAnswer;
+        $this->expectedAnswer   = $expectedAnswer;
     }
 
     /**
@@ -42,9 +43,6 @@ abstract class AbstractQuestionAssertion
         };
     }
 
-    /**
-     * @param string  $argument
-     */
     private function assertQuestionMatchesExpectation(string $argument): bool
     {
         return strpos($argument, $this->expectedQuestion) !== false;

--- a/test/ComponentInstallerTest.php
+++ b/test/ComponentInstallerTest.php
@@ -28,7 +28,6 @@ use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
-use Webmozart\Assert\Assert;
 
 use function count;
 use function dirname;
@@ -646,11 +645,11 @@ CONTENT
 
         $this->installer->onPostPackageInstall($event);
 
-        /** @psalm-suppress UnresolvableInclude */
-        $config = require vfsStream::url('project/config/application.config.php');
-        Assert::isNonEmptyMap($config);
-        Assert::keyExists($config, 'modules');
-        Assert::isNonEmptyList($config['modules']);
+        /**
+         * @psalm-suppress UnresolvableInclude
+         * @psalm-var array{modules:list<non-empty-string>} $config
+         */
+        $config  = require vfsStream::url('project/config/application.config.php');
         $modules = $config['modules'];
         self::assertEquals($result, $modules);
     }
@@ -753,11 +752,11 @@ CONTENT
         ]);
 
         $this->installer->onPostPackageInstall($event);
-        /** @psalm-suppress UnresolvableInclude */
-        $config = require vfsStream::url('project/config/application.config.php');
-        Assert::isNonEmptyMap($config);
-        Assert::keyExists($config, 'modules');
-        Assert::isNonEmptyList($config['modules']);
+        /**
+         * @psalm-suppress UnresolvableInclude
+         * @psalm-var array{modules:list<non-empty-string>} $config
+         */
+        $config  = require vfsStream::url('project/config/application.config.php');
         $modules = $config['modules'];
         self::assertEquals($result, $modules);
     }
@@ -1247,11 +1246,11 @@ CONTENT
         ]);
 
         $this->installer->onPostPackageInstall($event);
-        /** @psalm-suppress UnresolvableInclude */
-        $config = require vfsStream::url('project/config/application.config.php');
-        Assert::isNonEmptyMap($config);
-        Assert::keyExists($config, 'modules');
-        Assert::isNonEmptyList($config['modules']);
+        /**
+         * @psalm-suppress UnresolvableInclude
+         * @psalm-var array{modules:list<non-empty-string>} $config
+         */
+        $config  = require vfsStream::url('project/config/application.config.php');
         $modules = $config['modules'];
         self::assertEquals([
             'Some\Component',
@@ -1295,11 +1294,11 @@ CONTENT
         ]);
 
         $this->installer->onPostPackageInstall($event);
-        /** @psalm-suppress UnresolvableInclude */
-        $config = require vfsStream::url('project/config/application.config.php');
-        Assert::isNonEmptyMap($config);
-        Assert::keyExists($config, 'modules');
-        Assert::isNonEmptyList($config['modules']);
+        /**
+         * @psalm-suppress UnresolvableInclude
+         * @psalm-var array{modules:list<non-empty-string>} $config
+         */
+        $config  = require vfsStream::url('project/config/application.config.php');
         $modules = $config['modules'];
         self::assertEquals([
             'Some\Component',
@@ -1548,22 +1547,22 @@ CONFIG;
         $this->prepareEventForPackageProviderDetection($event, 'some/component');
 
         $this->installer->onPostPackageInstall($event);
-        /** @psalm-suppress UnresolvableInclude */
-        $config = require vfsStream::url('project/config/modules.config.php');
-        Assert::isNonEmptyMap($config);
-        Assert::keyExists($config, 'modules');
-        Assert::isNonEmptyList($config['modules']);
+        /**
+         * @psalm-suppress UnresolvableInclude
+         * @psalm-var array{modules:list<non-empty-string>} $config
+         */
+        $config  = require vfsStream::url('project/config/modules.config.php');
         $modules = $config['modules'];
         self::assertEquals([
             'Laminas\Router',
             'Laminas\Validator',
             'Application',
         ], $modules);
-        /** @psalm-suppress UnresolvableInclude */
-        $config = require vfsStream::url('project/config/development.config.php');
-        Assert::isNonEmptyMap($config);
-        Assert::keyExists($config, 'modules');
-        Assert::isNonEmptyList($config['modules']);
+        /**
+         * @psalm-suppress UnresolvableInclude
+         * @psalm-var array{modules:list<non-empty-string>} $config
+         */
+        $config  = require vfsStream::url('project/config/development.config.php');
         $modules = $config['modules'];
         self::assertEquals(['Some\Component'], $modules);
     }
@@ -1612,11 +1611,11 @@ CONFIG;
             ->willReturn('some/module');
 
         $this->installer->onPostPackageInstall($event);
-        /** @psalm-suppress UnresolvableInclude */
-        $config = require vfsStream::url('project/config/modules.config.php');
-        Assert::isNonEmptyMap($config);
-        Assert::keyExists($config, 'modules');
-        Assert::isNonEmptyList($config['modules']);
+        /**
+         * @psalm-suppress UnresolvableInclude
+         * @psalm-var array{modules:list<non-empty-string>} $config
+         */
+        $config  = require vfsStream::url('project/config/modules.config.php');
         $modules = $config['modules'];
         self::assertEquals([
             'Laminas\Router',

--- a/test/ComponentInstallerTest.php
+++ b/test/ComponentInstallerTest.php
@@ -249,7 +249,7 @@ CONTENT
             return strstr($argument, 'Dependency SomeDependency is not registered in the configuration');
         }))->shouldBeCalled();
 
-        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
+        $this->installer->onPostPackageInstall($event->reveal());
     }
 
     /**
@@ -628,7 +628,7 @@ CONTENT
             return strstr($argument, sprintf('Installing %s from package some/component', $packageName));
         }))->shouldBeCalled();
 
-        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
+        $this->installer->onPostPackageInstall($event->reveal());
 
         $config  = include vfsStream::url('project/config/application.config.php');
         $modules = $config['modules'];
@@ -741,7 +741,7 @@ CONTENT
             return strstr($argument, 'Installing SomeModule from package some/module');
         }))->shouldBeCalled();
 
-        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
+        $this->installer->onPostPackageInstall($event->reveal());
 
         $config  = include vfsStream::url('project/config/application.config.php');
         $modules = $config['modules'];
@@ -762,7 +762,7 @@ CONTENT
         $event->isDevMode()->willReturn(false);
         $event->getOperation()->shouldNotBeCalled();
 
-        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
+        $this->installer->onPostPackageInstall($event->reveal());
     }
 
     public function testPostPackageInstallDoesNothingIfComposerExtraIsEmpty(): void
@@ -778,7 +778,7 @@ CONTENT
         $event->isDevMode()->willReturn(true);
         $event->getOperation()->willReturn($operation->reveal());
 
-        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
+        $this->installer->onPostPackageInstall($event->reveal());
     }
 
     public function testOnPostPackageInstallReturnsEarlyIfApplicationConfigIsMissing(): void
@@ -800,7 +800,7 @@ CONTENT
         $event->isDevMode()->willReturn(true);
         $event->getOperation()->willReturn($operation->reveal());
 
-        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
+        $this->installer->onPostPackageInstall($event->reveal());
     }
 
     public function testPostPackageInstallDoesNothingIfLaminasExtraSectionDoesNotContainComponentOrModule(): void
@@ -816,7 +816,7 @@ CONTENT
         $event->isDevMode()->willReturn(true);
         $event->getOperation()->willReturn($operation->reveal());
 
-        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
+        $this->installer->onPostPackageInstall($event->reveal());
     }
 
     public function testOnPostPackageInstallDoesNotPromptIfPackageIsAlreadyInConfiguration(): void
@@ -847,7 +847,7 @@ CONTENT
 
         $this->io->ask(Argument::any())->shouldNotBeCalled();
 
-        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
+        $this->installer->onPostPackageInstall($event->reveal());
         $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
         $this->assertStringContainsString("'Some\Component'", $config);
     }
@@ -887,7 +887,7 @@ CONTENT
             return strpos($argument, 'Installing Some\Component from package some/component');
         }))->shouldBeCalled();
 
-        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
+        $this->installer->onPostPackageInstall($event->reveal());
         $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
         $this->assertStringContainsString("'Some\Component'", $config);
     }
@@ -957,7 +957,7 @@ CONTENT
             return strstr($argument, 'Installing Some\Component from package some/component');
         }))->shouldBeCalled();
 
-        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
+        $this->installer->onPostPackageInstall($event->reveal());
         $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
         $this->assertStringContainsString("'Some\Component'", $config);
     }
@@ -1068,7 +1068,7 @@ CONTENT
             return strstr($argument, 'Installing Other\Component from package some/component');
         }))->shouldBeCalled();
 
-        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
+        $this->installer->onPostPackageInstall($event->reveal());
         $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
         $this->assertStringContainsString("'Some\Component'", $config);
         $this->assertStringContainsString("'Other\Component'", $config);
@@ -1137,7 +1137,7 @@ CONTENT
             return strstr($argument, 'Installing Some\Component from package some/component');
         }))->shouldBeCalled();
 
-        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
+        $this->installer->onPostPackageInstall($event->reveal());
         $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
         $this->assertStringContainsString("'Some\Component'", $config);
 
@@ -1203,7 +1203,7 @@ CONTENT
             return strstr($argument, 'Installing Other\Component from package other/component');
         }))->shouldBeCalled();
 
-        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
+        $this->installer->onPostPackageInstall($event->reveal());
         $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
         $this->assertStringContainsString("'Other\Component'", $config);
     }
@@ -1271,7 +1271,7 @@ CONTENT
             return strstr($argument, 'Installing Some\Component from package some/component');
         }))->shouldBeCalled();
 
-        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
+        $this->installer->onPostPackageInstall($event->reveal());
         $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
         $this->assertStringContainsString("'Some\Component'", $config);
 
@@ -1301,7 +1301,7 @@ CONTENT
             return strstr($argument, 'Installing Other\Component from package other/component');
         }))->shouldBeCalled();
 
-        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
+        $this->installer->onPostPackageInstall($event->reveal());
         $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
         $this->assertStringContainsString("'Other\Component'", $config);
     }
@@ -1312,7 +1312,7 @@ CONTENT
         $event->isDevMode()->willReturn(false);
         $event->getOperation()->shouldNotBeCalled();
 
-        $this->assertNull($this->installer->onPostPackageUninstall($event->reveal()));
+        $this->installer->onPostPackageUninstall($event->reveal());
     }
 
     public function testOnPostPackageUninstallReturnsEarlyIfNoRelevantConfigFilesAreFound(): void
@@ -1321,7 +1321,7 @@ CONTENT
         $event->isDevMode()->willReturn(true);
         $event->getOperation()->shouldNotBeCalled();
 
-        $this->assertNull($this->installer->onPostPackageUninstall($event->reveal()));
+        $this->installer->onPostPackageUninstall($event->reveal());
     }
 
     public function testOnPostPackageUninstallRemovesPackageFromConfiguration(): void
@@ -1359,7 +1359,7 @@ CONTENT
             }))
             ->shouldBeCalled();
 
-        $this->assertNull($this->installer->onPostPackageUninstall($event->reveal()));
+        $this->installer->onPostPackageUninstall($event->reveal());
 
         $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
         $this->assertStringNotContainsString('Some\Component', $config);
@@ -1408,7 +1408,7 @@ CONTENT
             }))
             ->shouldBeCalled();
 
-        $this->assertNull($this->installer->onPostPackageUninstall($event->reveal()));
+        $this->installer->onPostPackageUninstall($event->reveal());
 
         $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
         $this->assertStringNotContainsString('Some\Component', $config);
@@ -1482,8 +1482,8 @@ CONTENT
             return strstr($argument, 'Installing Some\Module from package some/module');
         }))->shouldBeCalled();
 
-        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
-        $config  = include vfsStream::url('project/config/application.config.php');
+        $this->installer->onPostPackageInstall($event->reveal());
+        $config = include vfsStream::url('project/config/application.config.php');
         $modules = $config['modules'];
         $this->assertEquals([
             'Some\Component',
@@ -1588,8 +1588,8 @@ CONTENT
             return strstr($argument, 'Installing Some\Component from package some/package');
         }))->shouldBeCalled();
 
-        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
-        $config  = include vfsStream::url('project/config/application.config.php');
+        $this->installer->onPostPackageInstall($event->reveal());
+        $config = include vfsStream::url('project/config/application.config.php');
         $modules = $config['modules'];
         $this->assertEquals([
             'Some\Component',
@@ -1697,8 +1697,8 @@ CONTENT
             return strstr($argument, 'Installing Some\Component from package some/package');
         }))->shouldBeCalled();
 
-        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
-        $config  = include vfsStream::url('project/config/application.config.php');
+        $this->installer->onPostPackageInstall($event->reveal());
+        $config = include vfsStream::url('project/config/application.config.php');
         $modules = $config['modules'];
         $this->assertEquals([
             'Some\Component',
@@ -1961,8 +1961,8 @@ CONFIG;
 
         $this->rootPackage->getRequires()->willReturn([]);
 
-        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
-        $config  = include vfsStream::url('project/config/modules.config.php');
+        $this->installer->onPostPackageInstall($event->reveal());
+        $config = include vfsStream::url('project/config/modules.config.php');
         $modules = $config['modules'];
         $this->assertEquals([
             'Laminas\Router',
@@ -2020,8 +2020,8 @@ CONFIG;
             ->willReturn('some/module');
         $this->rootPackage->getRequires()->willReturn([]);
 
-        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
-        $config  = include vfsStream::url('project/config/modules.config.php');
+        $this->installer->onPostPackageInstall($event->reveal());
+        $config = include vfsStream::url('project/config/modules.config.php');
         $modules = $config['modules'];
         $this->assertEquals([
             'Laminas\Router',

--- a/test/ComponentInstallerTest.php
+++ b/test/ComponentInstallerTest.php
@@ -11,25 +11,25 @@ namespace LaminasTest\ComponentInstaller;
 use Composer\Composer;
 use Composer\Config;
 use Composer\DependencyResolver\Operation\InstallOperation;
+use Composer\DependencyResolver\Operation\UninstallOperation;
 use Composer\DependencyResolver\Pool;
-use Composer\Installer\InstallationManager;
 use Composer\Installer\PackageEvent;
 use Composer\IO\IOInterface;
-use Composer\Package\PackageInterface;
-use Composer\Package\RootPackageInterface;
+use LaminasTest\ComponentInstaller\TestAsset\NativeTypehintedRootPackageInterface as RootPackageInterface;
 use Composer\Repository\PlatformRepository;
 use Composer\Repository\RepositoryManager;
 use Composer\Repository\RootPackageRepository;
 use Laminas\ComponentInstaller\ComponentInstaller;
 use Laminas\ComponentInstaller\PackageProvider\PackageProviderDetectionFactory;
+use LaminasTest\ComponentInstaller\TestAsset\NativeTypehintedInstallationManager as InstallationManager;
+use LaminasTest\ComponentInstaller\TestAsset\NativeTypehintedPackageInterface as PackageInterface;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionObject;
-
+use Webmozart\Assert\Assert;
+use function count;
 use function dirname;
 use function file_get_contents;
 use function implode;
@@ -37,43 +37,48 @@ use function is_string;
 use function method_exists;
 use function mkdir;
 use function preg_match;
+use function preg_quote;
 use function sprintf;
 use function strpos;
-use function strstr;
 
 class ComponentInstallerTest extends TestCase
 {
-    use ProphecyTrait;
-
-    /** @var vfsStreamDirectory */
+    /**
+     * @var vfsStreamDirectory
+     */
     private $projectRoot;
 
     /** @var ComponentInstaller */
     private $installer;
 
     /**
-     * @var Composer|ObjectProphecy
-     * @psalm-var Composer&ObjectProphecy
+     * @var Composer|MockObject
+     * @psalm-var Composer&MockObject
      */
     private $composer;
 
     /**
-     * @var RootPackageInterface|ObjectProphecy
-     * @psalm-var RootPackageInterface&ObjectProphecy
+     * @var RootPackageInterface|MockObject
+     * @psalm-var RootPackageInterface&MockObject
      */
     private $rootPackage;
 
     /**
-     * @var IOInterface|ObjectProphecy
-     * @psalm-var IOInterface&ObjectProphecy
+     * @var IOInterface|MockObject
+     * @psalm-var IOInterface&MockObject
      */
     private $io;
 
     /**
-     * @var InstallationManager|ObjectProphecy
-     * @psalm-var InstallationManager&ObjectProphecy
+     * @var InstallationManager|MockObject
+     * @psalm-var InstallationManager&MockObject
      */
     private $installationManager;
+
+    /**
+     * @var array{laminas?:array{component-whitelist?:list<non-empty-string>}}
+     */
+    private $rootPackageExtra = [];
 
     protected function setUp(): void
     {
@@ -82,44 +87,64 @@ class ComponentInstallerTest extends TestCase
             vfsStream::url('project')
         );
 
-        /** @psalm-var Composer&ObjectProphecy $composer */
-        $composer       = $this->prophesize(Composer::class);
+        /** @psalm-var Composer&MockObject $composer */
+        $composer       = $this->createMock(Composer::class);
         $this->composer = $composer;
 
-        /** @psalm-var RootPackageInterface&ObjectProphecy $rootPackage */
-        $rootPackage       = $this->prophesize(RootPackageInterface::class);
+        /** @psalm-var RootPackageInterface&MockObject $rootPackage */
+        $rootPackage       = $this->createMock(RootPackageInterface::class);
         $this->rootPackage = $rootPackage;
+        $this->rootPackage
+            ->method('getExtra')
+            ->willReturnCallback(function (): array {
+                return $this->rootPackageExtra;
+            });
 
-        /** @psalm-var IOInterface&ObjectProphecy $io */
-        $io       = $this->prophesize(IOInterface::class);
+        /** @psalm-var IOInterface&MockObject $io */
+        $io       = $this->createMock(IOInterface::class);
         $this->io = $io;
 
-        $this->rootPackage->getDevRequires()->willReturn([]);
-        $this->rootPackage->getExtra()->willReturn([]);
         if (false === PackageProviderDetectionFactory::isComposerV1()) {
-            $config = $this->prophesize(Config::class);
-            $this->composer->getConfig()->willReturn($config->reveal());
-            $repositoryManager = $this->prophesize(RepositoryManager::class);
-            $localRepository   = $this->prophesize(PlatformRepository::class);
-            $localRepository->getPackages()->willReturn([]);
-            $repositoryManager->getLocalRepository()->willReturn($localRepository->reveal());
-            $this->composer->getRepositoryManager()->willReturn($repositoryManager->reveal());
-            $this->rootPackage->getProvides()->willReturn([]);
-            $this->rootPackage->getReplaces()->willReturn([]);
-            $this->rootPackage->setRepository(Argument::type(RootPackageRepository::class))->willReturn([]);
+            $config = $this->createMock(Config::class);
+            $this->composer
+                ->method('getConfig')
+                ->willReturn($config);
+            $repositoryManager = $this->createMock(RepositoryManager::class);
+            $localRepository   = $this->createMock(PlatformRepository::class);
+            $localRepository
+                ->method('getPackages')
+                ->willReturn([]);
+            $repositoryManager
+                ->method('getLocalRepository')
+                ->willReturn($localRepository);
+            $this->composer
+                ->method('getRepositoryManager')
+                ->willReturn($repositoryManager);
+
+            $this->rootPackage
+                ->method('setRepository')
+                ->with(self::callback(static function (object $repository): bool {
+                    self::assertInstanceOf(RootPackageRepository::class, $repository);
+                    return true;
+                }));
         }
 
-        $this->composer->getPackage()->willReturn($this->rootPackage->reveal());
+        $this->composer
+            ->method('getPackage')
+            ->willReturn($this->rootPackage);
+
         $this->installer->activate(
-            $this->composer->reveal(),
-            $this->io->reveal()
+            $this->composer,
+            $this->io
         );
 
-        /** @psalm-var InstallationManager&ObjectProphecy $installationManager */
-        $installationManager       = $this->prophesize(InstallationManager::class);
+        /** @psalm-var InstallationManager&MockObject $installationManager */
+        $installationManager       = $this->createMock(InstallationManager::class);
         $this->installationManager = $installationManager;
 
-        $this->composer->getInstallationManager()->willReturn($installationManager->reveal());
+        $this->composer
+            ->method('getInstallationManager')
+            ->willReturn($installationManager);
     }
 
     /**
@@ -199,57 +224,59 @@ class Module {
 CONTENT
         );
 
-        /** @var PackageInterface|ObjectProphecy $package */
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getName()->willReturn('some/component');
-        $package->getExtra()->willReturn([
-            'laminas' => [
-                'component' => 'SomeComponent',
-            ],
-        ]);
-        $package->getAutoload()->willReturn([
-            'psr-0' => [
-                'SomeComponent\\' => 'src/',
-            ],
-        ]);
+        $package = $this->createMock(PackageInterface::class);
+        $package
+            ->method('getName')
+            ->willReturn('some/component');
 
-        $this->installationManager->getInstallPath(Argument::exact($package->reveal()))
+        $package
+            ->method('getExtra')
+            ->willReturn([
+                'laminas' => [
+                    'component' => 'SomeComponent',
+                ],
+            ]);
+        $package
+            ->method('getAutoload')
+            ->willReturn([
+                'psr-0' => [
+                    'SomeComponent\\' => 'src/',
+                ],
+            ]);
+
+        $this->installationManager
+            ->method('getInstallPath')
+            ->with($package)
             ->willReturn(vfsStream::url('project/' . $installPath));
 
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
+        $operation = $this->createMock(InstallOperation::class);
+        $operation
+            ->method('getPackage')
+            ->willReturn($package);
 
-        /** @psalm-var PackageEvent&ObjectProphecy $event */
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
+        $event = $this->createMock(PackageEvent::class);
+        $event->method('isDevMode')->willReturn(true);
+        $event->method('getOperation')->willReturn($operation);
         $this->prepareEventForPackageProviderDetection($event, 'some/component');
 
         $this->rootPackage
-            ->getName()
+            ->method('getName')
             ->willReturn('some/component');
 
-        $this->rootPackage
-            ->getRequires()
-            ->willReturn([]);
+        $this->createOutputAssertions([
+            'Installing SomeComponent from package some/component',
+            'Dependency SomeDependency is not registered in the configuration',
+        ]);
 
-        $this->io->ask(Argument::that(function ($argument) {
-            return ComponentInstallerTest::assertPrompt($argument, 'SomeComponent');
-        }), 1)->willReturn(1);
+        $this->createInputAssertions([
+             RememberedAnswerQuestionAssertion::inject(
+                 'SomeComponent',
+                 1,
+                 true
+             )
+         ]);
 
-        $this->io->ask(Argument::that(function ($argument) {
-            return ComponentInstallerTest::assertPrompt($argument);
-        }), 'y')->willReturn('y');
-
-        $this->io->write(Argument::that(function ($argument) {
-            return strstr($argument, 'Installing SomeComponent from package some/component');
-        }))->shouldBeCalled();
-
-        $this->io->write(Argument::that(function ($argument) {
-            return strstr($argument, 'Dependency SomeDependency is not registered in the configuration');
-        }))->shouldBeCalled();
-
-        $this->installer->onPostPackageInstall($event->reveal());
+        $this->installer->onPostPackageInstall($event);
     }
 
     /**
@@ -587,52 +614,48 @@ CONTENT
                 CONTENT
         );
 
-        /** @psalm-var PackageInterface&ObjectProphecy $package */
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getName()->willReturn('some/component');
-        $package->getExtra()->willReturn([
+        $package = $this->createMock(PackageInterface::class);
+        $package->method('getName')->willReturn('some/component');
+        $package->method('getExtra')->willReturn([
             'laminas' => [
                 'component' => $packageName,
             ],
         ]);
-        $package->getAutoload()->willReturn([
+        $package->method('getAutoload')->willReturn([
             $autoloading => $autoload,
         ]);
 
-        $this->installationManager->getInstallPath(Argument::exact($package->reveal()))
+        $this->installationManager
+            ->method('getInstallPath')
+            ->with($package)
             ->willReturn(vfsStream::url('project/' . $installPath));
 
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
+        $operation = $this->createMock(InstallOperation::class);
+        $operation->method('getPackage')->willReturn($package);
 
-        /** @psalm-var PackageEvent&ObjectProphecy $event */
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
+        $event = $this->createMock(PackageEvent::class);
+        $event->method('isDevMode')->willReturn(true);
+        $event->method('getOperation')->willReturn($operation);
         $this->prepareEventForPackageProviderDetection($event, 'some/component');
 
-        $this->rootPackage->getRequires()->willReturn([]);
-        $this->rootPackage
-            ->getName()
-            ->willReturn('some/component');
+        $this->rootPackage->method('getName')->willReturn('some/component');
 
-        $this->io->ask(Argument::that(function ($argument) use ($packageName) {
-            return ComponentInstallerTest::assertPrompt($argument, $packageName);
-        }), 1)->willReturn(1);
+        $this->createOutputAssertions([
+            sprintf('Installing %s from package some/component', $packageName),
+        ]);
+        $this->createInputAssertions([
+            RememberedAnswerQuestionAssertion::inject($packageName, 1, true),
+        ]);
 
-        $this->io->ask(Argument::that(function ($argument) {
-            return ComponentInstallerTest::assertPrompt($argument);
-        }), 'y')->willReturn('y');
+        $this->installer->onPostPackageInstall($event);
 
-        $this->io->write(Argument::that(function ($argument) use ($packageName) {
-            return strstr($argument, sprintf('Installing %s from package some/component', $packageName));
-        }))->shouldBeCalled();
-
-        $this->installer->onPostPackageInstall($event->reveal());
-
-        $config  = include vfsStream::url('project/config/application.config.php');
+        /** @psalm-suppress UnresolvableInclude */
+        $config = require vfsStream::url('project/config/application.config.php');
+        Assert::isNonEmptyMap($config);
+        Assert::keyExists($config, 'modules');
+        Assert::isNonEmptyList($config['modules']);
         $modules = $config['modules'];
-        $this->assertEquals($result, $modules);
+        self::assertEquals($result, $modules);
     }
 
     /**
@@ -707,85 +730,82 @@ CONTENT
             '<' . "?php\nreturn [\n    'modules' => [" . $modules . "\n    ],\n];"
         );
 
-        /** @psalm-var PackageInterface&ObjectProphecy $package */
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getName()->willReturn('some/module');
-        $package->getExtra()->willReturn([
+        $package = $this->createMock(PackageInterface::class);
+        $package->method('getName')->willReturn('some/module');
+        $package->method('getExtra')->willReturn([
             'laminas' => [
                 'module' => 'SomeModule',
             ],
         ]);
-        $package->getAutoload()->willReturn([]);
 
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
+        $operation = $this->createMock(InstallOperation::class);
+        $operation->method('getPackage')->willReturn($package);
 
-        /** @psalm-var PackageEvent&ObjectProphecy $event */
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
+        $event = $this->createMock(PackageEvent::class);
+        $event->method('isDevMode')->willReturn(true);
+        $event->method('getOperation')->willReturn($operation);
         $this->prepareEventForPackageProviderDetection($event, 'some/module');
 
-        $this->rootPackage->getRequires()->willReturn([]);
-        $this->rootPackage->getName()->willReturn('some/component');
+        $this->rootPackage->method('getName')->willReturn('some/component');
 
-        $this->io->ask(Argument::that(function ($argument) {
-            return ComponentInstallerTest::assertPrompt($argument, 'SomeModule');
-        }), 1)->willReturn(1);
+        $this->createOutputAssertions([
+            'Installing SomeModule from package some/module',
+        ]);
+        $this->createInputAssertions([
+            RememberedAnswerQuestionAssertion::inject('SomeModule', 1, true)
+        ]);
 
-        $this->io->ask(Argument::that(function ($argument) {
-            return ComponentInstallerTest::assertPrompt($argument);
-        }), 'y')->willReturn('y');
-
-        $this->io->write(Argument::that(function ($argument) {
-            return strstr($argument, 'Installing SomeModule from package some/module');
-        }))->shouldBeCalled();
-
-        $this->installer->onPostPackageInstall($event->reveal());
-
-        $config  = include vfsStream::url('project/config/application.config.php');
+        $this->installer->onPostPackageInstall($event);
+        /** @psalm-suppress UnresolvableInclude */
+        $config = require vfsStream::url('project/config/application.config.php');
+        Assert::isNonEmptyMap($config);
+        Assert::keyExists($config, 'modules');
+        Assert::isNonEmptyList($config['modules']);
         $modules = $config['modules'];
-        $this->assertEquals($result, $modules);
+        self::assertEquals($result, $modules);
     }
 
     public function testSubscribesToExpectedEvents(): void
     {
-        $this->assertEquals([
+        self::assertEquals([
             'post-package-install'   => 'onPostPackageInstall',
             'post-package-uninstall' => 'onPostPackageUninstall',
-        ], $this->installer->getSubscribedEvents());
+        ], ComponentInstaller::getSubscribedEvents());
     }
 
     public function testOnPostPackageInstallReturnsEarlyIfEventIsNotInDevMode(): void
     {
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(false);
-        $event->getOperation()->shouldNotBeCalled();
+        $event = $this->createMock(PackageEvent::class);
+        $event->method('isDevMode')->willReturn(false);
+        $event->expects(self::never())->method('getOperation');
 
-        $this->installer->onPostPackageInstall($event->reveal());
+        $this->installer->onPostPackageInstall($event);
     }
 
     public function testPostPackageInstallDoesNothingIfComposerExtraIsEmpty(): void
     {
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getName()->willReturn('some/component');
-        $package->getExtra()->willReturn([]);
+        $package = $this->createMock(PackageInterface::class);
+        $package->method('getName')->willReturn('some/component');
 
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
+        $operation = $this->createMock(InstallOperation::class);
+        $operation->method('getPackage')->willReturn($package);
 
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
+        $event = $this->createMock(PackageEvent::class);
+        $event->method('isDevMode')->willReturn(true);
+        $event->method('getOperation')->willReturn($operation);
 
-        $this->installer->onPostPackageInstall($event->reveal());
+        $this->io
+            ->expects(self::never())
+            ->method(self::anything());
+
+        $this->installer->onPostPackageInstall($event);
     }
 
     public function testOnPostPackageInstallReturnsEarlyIfApplicationConfigIsMissing(): void
     {
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getName()->willReturn('some/component');
-        $package->getExtra()->willReturn([
+        $package = $this->createMock(PackageInterface::class);
+        $package->method('getName')->willReturn('some/component');
+        $package->method('getExtra')->willReturn([
             'laminas' => [
                 'component'       => 'Some\\Component',
                 'config-provider' => 'Some\\Component\\ConfigProvider',
@@ -793,30 +813,30 @@ CONTENT
             ],
         ]);
 
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
+        $this->io
+            ->expects(self::never())
+            ->method(self::anything());
 
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
-
-        $this->installer->onPostPackageInstall($event->reveal());
+        $this->installer->onPostPackageInstall($event);
     }
 
     public function testPostPackageInstallDoesNothingIfLaminasExtraSectionDoesNotContainComponentOrModule(): void
     {
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getName()->willReturn('some/component');
-        $package->getExtra()->willReturn(['laminas' => []]);
+        $package = $this->createMock(PackageInterface::class);
+        $package->method('getName')->willReturn('some/component');
+        $package->method('getExtra')->willReturn(['laminas' => []]);
 
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
+        $operation = $this->createMock(InstallOperation::class);
+        $operation->method('getPackage')->willReturn($package);
 
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
+        $event = $this->createMock(PackageEvent::class);
+        $event->method('isDevMode')->willReturn(true);
+        $event->method('getOperation')->willReturn($operation);
+        $this->io
+            ->expects(self::never())
+            ->method(self::anything());
 
-        $this->installer->onPostPackageInstall($event->reveal());
+        $this->installer->onPostPackageInstall($event);
     }
 
     public function testOnPostPackageInstallDoesNotPromptIfPackageIsAlreadyInConfiguration(): void
@@ -825,667 +845,109 @@ CONTENT
             '<' . "?php\nreturn [\n    'modules' => [\n        'Some\Component',\n    ]\n];"
         );
 
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getName()->willReturn('some/component');
-        $package->getExtra()->willReturn([
+        $package = $this->createMock(PackageInterface::class);
+        $package->method('getName')->willReturn('some/component');
+        $package->method('getExtra')->willReturn([
             'laminas' => [
                 'component' => 'Some\\Component',
             ],
         ]);
-        $package->getAutoload()->willReturn([]);
 
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
+        $operation = $this->createMock(InstallOperation::class);
+        $operation->method('getPackage')->willReturn($package);
 
-        /** @psalm-var PackageEvent&ObjectProphecy $event */
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
+        $event = $this->createMock(PackageEvent::class);
+        $event->method('isDevMode')->willReturn(true);
+        $event->method('getOperation')->willReturn($operation);
         $this->prepareEventForPackageProviderDetection($event, 'some/component');
-        $this->rootPackage->getRequires()->willReturn([]);
-        $this->rootPackage->getName()->willReturn('some/component');
+        $this->rootPackage->method('getName')->willReturn('some/component');
 
-        $this->io->ask(Argument::any())->shouldNotBeCalled();
+        $this->io
+            ->expects(self::never())
+            ->method('ask');
 
-        $this->installer->onPostPackageInstall($event->reveal());
+        $this->installer->onPostPackageInstall($event);
         $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
-        $this->assertStringContainsString("'Some\Component'", $config);
+        self::assertStringContainsString("'Some\Component'", $config);
     }
 
     public function testOnPostPackageInstallDoesNotPromptForWhitelistedPackages(): void
     {
         $this->createApplicationConfig();
 
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getName()->willReturn('some/component');
-        $package->getExtra()->willReturn([
+        $package = $this->createMock(PackageInterface::class);
+        $package->method('getName')->willReturn('some/component');
+        $package->method('getExtra')->willReturn([
             'laminas' => [
                 'component' => 'Some\\Component',
             ],
         ]);
-        $package->getAutoload()->willReturn([]);
 
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
+        $operation = $this->createMock(InstallOperation::class);
+        $operation->method('getPackage')->willReturn($package);
 
-        /** @psalm-var PackageEvent&ObjectProphecy $event */
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
+        $event = $this->createMock(PackageEvent::class);
+        $event->method('isDevMode')->willReturn(true);
+        $event->method('getOperation')->willReturn($operation);
         $this->prepareEventForPackageProviderDetection($event, 'some/component');
 
-        $this->rootPackage->getRequires()->willReturn([]);
-        $this->rootPackage->getName()->willReturn('some/component');
-
-        $this->rootPackage->getExtra()->willReturn([
+        $this->rootPackage->method('getName')->willReturn('some/component');
+        $this->rootPackageExtra = [
             'laminas' => [
                 'component-whitelist' => ['some/component'],
             ],
+        ];
+
+        $this->createOutputAssertions([
+            'Installing Some\Component from package some/component',
         ]);
+        $this->io
+            ->expects(self::never())
+            ->method('ask');
 
-        $this->io->write(Argument::that(function ($argument) {
-            return strpos($argument, 'Installing Some\Component from package some/component');
-        }))->shouldBeCalled();
-
-        $this->installer->onPostPackageInstall($event->reveal());
+        $this->installer->onPostPackageInstall($event);
         $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
-        $this->assertStringContainsString("'Some\Component'", $config);
+        self::assertStringContainsString("'Some\Component'", $config);
     }
 
     public function testOnPostPackageInstallPromptsForConfigOptions(): void
     {
         $this->createApplicationConfig();
 
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getName()->willReturn('some/component');
-        $package->getExtra()->willReturn([
+        $package = $this->createMock(PackageInterface::class);
+        $package->method('getName')->willReturn('some/component');
+        $package->method('getExtra')->willReturn([
             'laminas' => [
                 'component' => 'Some\\Component',
             ],
         ]);
-        $package->getAutoload()->willReturn([]);
 
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
+        $this->installer->onPostPackageUninstall($event);
 
-        /** @psalm-var PackageEvent&ObjectProphecy $event */
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
+        $event = $this->createMock(PackageEvent::class);
+        $event->method('isDevMode')->willReturn(true);
+        $event->method('getOperation')->willReturn($operation);
         $this->prepareEventForPackageProviderDetection($event, 'some/component');
 
-        $this->rootPackage->getRequires()->willReturn([]);
-        $this->rootPackage->getName()->willReturn('some/component');
 
-        $this->io->ask(Argument::that(function ($argument) {
-            if (! is_string($argument)) {
-                return false;
-            }
+        $this->rootPackage->method('getName')->willReturn('some/module');
 
-            if (
-                false === strpos(
-                    $argument,
-                    "Please select which config file you wish to inject 'Some\Component' into"
-                )
-            ) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'Do not inject')) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'application.config.php')) {
-                return false;
-            }
-
-            return true;
-        }), 1)->willReturn(1);
-
-        $this->io->ask(Argument::that(function ($argument) {
-            if (! is_string($argument)) {
-                return false;
-            }
-            if (false === strpos($argument, 'Remember')) {
-                return false;
-            }
-
-            return true;
-        }), 'y')->willReturn('y');
-
-        $this->io->write(Argument::that(function ($argument) {
-            return strstr($argument, 'Installing Some\Component from package some/component');
-        }))->shouldBeCalled();
-
-        $this->installer->onPostPackageInstall($event->reveal());
-        $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
-        $this->assertStringContainsString("'Some\Component'", $config);
-    }
-
-    public function testOnPostPackageInstallPromptsForConfigOptionsWhenDefinedAsArrays(): void
-    {
-        $this->createApplicationConfig();
-
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getName()->willReturn('some/component');
-        $package->getExtra()->willReturn([
-            'laminas' => [
-                'component' => [
-                    'Some\\Component',
-                    'Other\\Component',
-                ],
-            ],
+        $this->createInputAssertions([
+            RememberedAnswerQuestionAssertion::inject('Some\Module', 1, true),
         ]);
-        $package->getAutoload()->willReturn([]);
 
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
-
-        /** @psalm-var PackageEvent&ObjectProphecy $event */
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
-        $this->prepareEventForPackageProviderDetection($event, 'some/component');
-
-        $this->rootPackage->getRequires()->willReturn([]);
-        $this->rootPackage->getName()->willReturn('some/component');
-
-        $this->io->ask(Argument::that(function ($argument) {
-            if (! is_string($argument)) {
-                return false;
-            }
-
-            if (
-                false === strpos(
-                    $argument,
-                    "Please select which config file you wish to inject 'Some\Component' into"
-                )
-            ) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'Do not inject')) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'application.config.php')) {
-                return false;
-            }
-
-            return true;
-        }), 1)->willReturn(1);
-
-        $this->io->ask(Argument::that(function ($argument) {
-            if (! is_string($argument)) {
-                return false;
-            }
-
-            if (
-                false === strpos(
-                    $argument,
-                    "Please select which config file you wish to inject 'Other\Component' into"
-                )
-            ) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'Do not inject')) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'application.config.php')) {
-                return false;
-            }
-
-            return true;
-        }), 1)->willReturn(1);
-
-        $io           = $this->io;
-        $askValidator = function ($argument): bool {
-            if (! is_string($argument)) {
-                    return false;
-            }
-            if (false === strpos($argument, 'Remember')) {
-                return false;
-            }
-
-            return true;
-        };
-        $io
-            ->ask(Argument::that($askValidator), 'y')
-            ->will(function () use ($io, $askValidator) {
-                $io
-                    ->ask(Argument::that($askValidator), 'y')
-                    ->willReturn('y');
-                return 'n';
-            });
-
-        $io->write(Argument::that(function ($argument) {
-            return strstr($argument, 'Installing Some\Component from package some/component');
-        }))->shouldBeCalled();
-
-        $io->write(Argument::that(function ($argument) {
-            return strstr($argument, 'Installing Other\Component from package some/component');
-        }))->shouldBeCalled();
-
-        $this->installer->onPostPackageInstall($event->reveal());
-        $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
-        $this->assertStringContainsString("'Some\Component'", $config);
-        $this->assertStringContainsString("'Other\Component'", $config);
-    }
-
-    public function testMultipleInvocationsOfOnPostPackageInstallCanPromptMultipleTimes(): void
-    {
-        // Do a first pass, with an initial package
-        $this->createApplicationConfig();
-
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getName()->willReturn('some/component');
-        $package->getExtra()->willReturn([
-            'laminas' => [
-                'component' => 'Some\\Component',
-            ],
+        $this->createOutputAssertions([
+            'Installing Some\Module from package some/module',
         ]);
-        $package->getAutoload()->willReturn([]);
 
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
-
-        /** @psalm-var PackageEvent&ObjectProphecy $event */
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
-        $this->prepareEventForPackageProviderDetection($event, 'some/component');
-
-        $this->io->ask(Argument::that(function ($argument) {
-            if (! is_string($argument)) {
-                return false;
-            }
-
-            if (
-                false === strpos(
-                    $argument,
-                    "Please select which config file you wish to inject 'Some\Component' into"
-                )
-            ) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'Do not inject')) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'application.config.php')) {
-                return false;
-            }
-
-            return true;
-        }), 1)->willReturn(1);
-
-        $this->io->ask(Argument::that(function ($argument) {
-            if (! is_string($argument)) {
-                return false;
-            }
-            if (false === strpos($argument, 'Remember')) {
-                return false;
-            }
-
-            return true;
-        }), 'y')->willReturn('n');
-
-        $this->io->write(Argument::that(function ($argument) {
-            return strstr($argument, 'Installing Some\Component from package some/component');
-        }))->shouldBeCalled();
-
-        $this->installer->onPostPackageInstall($event->reveal());
-        $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
-        $this->assertStringContainsString("'Some\Component'", $config);
-
-        // Now do a second pass, with another package
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getName()->willReturn('other/component');
-        $package->getExtra()->willReturn([
-            'laminas' => [
-                'component' => 'Other\\Component',
-            ],
-        ]);
-        $package->getAutoload()->willReturn([]);
-
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
-
-        /** @psalm-var PackageEvent&ObjectProphecy $event */
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
-        $this->prepareEventForPackageProviderDetection($event, 'other/component');
-
-        $this->rootPackage->getRequires()->willReturn([]);
-        $this->rootPackage->getName()->willReturn('other/component');
-
-        $this->io->ask(Argument::that(function ($argument) {
-            if (! is_string($argument)) {
-                return false;
-            }
-
-            if (
-                false === strpos(
-                    $argument,
-                    "Please select which config file you wish to inject 'Other\Component' into"
-                )
-            ) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'Do not inject')) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'application.config.php')) {
-                return false;
-            }
-
-            return true;
-        }), 1)->willReturn(1);
-
-        $this->io->ask(Argument::that(function ($argument) {
-            if (! is_string($argument)) {
-                return false;
-            }
-            if (false === strpos($argument, 'Remember')) {
-                return false;
-            }
-
-            return true;
-        }), 'y')->willReturn('y');
-
-        $this->io->write(Argument::that(function ($argument) {
-            return strstr($argument, 'Installing Other\Component from package other/component');
-        }))->shouldBeCalled();
-
-        $this->installer->onPostPackageInstall($event->reveal());
-        $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
-        $this->assertStringContainsString("'Other\Component'", $config);
-    }
-
-    public function testMultipleInvocationsOfOnPostPackageInstallCanReuseOptions(): void
-    {
-        // Do a first pass, with an initial package
-        $this->createApplicationConfig();
-
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getName()->willReturn('some/component');
-        $package->getExtra()->willReturn([
-            'laminas' => [
-                'component' => 'Some\\Component',
-            ],
-        ]);
-        $package->getAutoload()->willReturn([]);
-
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
-
-        /** @psalm-var PackageEvent&ObjectProphecy $event */
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
-        $this->prepareEventForPackageProviderDetection($event, 'some/component');
-
-        $this->io->ask(Argument::that(function ($argument) {
-            if (! is_string($argument)) {
-                return false;
-            }
-
-            if (
-                false === strpos(
-                    $argument,
-                    "Please select which config file you wish to inject 'Some\Component' into"
-                )
-            ) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'Do not inject')) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'application.config.php')) {
-                return false;
-            }
-
-            return true;
-        }), 1)->willReturn(1);
-
-        $this->io->ask(Argument::that(function ($argument) {
-            if (! is_string($argument)) {
-                return false;
-            }
-            if (false === strpos($argument, 'Remember')) {
-                return false;
-            }
-
-            return true;
-        }), 'y')->willReturn('y')->shouldBeCalledTimes(1);
-
-        $this->io->write(Argument::that(function ($argument) {
-            return strstr($argument, 'Installing Some\Component from package some/component');
-        }))->shouldBeCalled();
-
-        $this->installer->onPostPackageInstall($event->reveal());
-        $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
-        $this->assertStringContainsString("'Some\Component'", $config);
-
-        // Now do a second pass, with another package
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getName()->willReturn('other/component');
-        $package->getExtra()->willReturn([
-            'laminas' => [
-                'component' => 'Other\\Component',
-            ],
-        ]);
-        $package->getAutoload()->willReturn([]);
-
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
-
-        /** @psalm-var PackageEvent&ObjectProphecy $event */
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
-        $this->prepareEventForPackageProviderDetection($event, 'other/component');
-
-        $this->rootPackage->getRequires()->willReturn([]);
-        $this->rootPackage->getName()->willReturn('some/component');
-
-        $this->io->write(Argument::that(function ($argument) {
-            return strstr($argument, 'Installing Other\Component from package other/component');
-        }))->shouldBeCalled();
-
-        $this->installer->onPostPackageInstall($event->reveal());
-        $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
-        $this->assertStringContainsString("'Other\Component'", $config);
-    }
-
-    public function testOnPostPackageUninstallReturnsEarlyIfEventIsNotInDevMode(): void
-    {
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(false);
-        $event->getOperation()->shouldNotBeCalled();
-
-        $this->installer->onPostPackageUninstall($event->reveal());
-    }
-
-    public function testOnPostPackageUninstallReturnsEarlyIfNoRelevantConfigFilesAreFound(): void
-    {
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->shouldNotBeCalled();
-
-        $this->installer->onPostPackageUninstall($event->reveal());
-    }
-
-    public function testOnPostPackageUninstallRemovesPackageFromConfiguration(): void
-    {
-        $this->createApplicationConfig(
-            '<' . "?php\nreturn [\n    'modules' => [\n        'Some\Component',\n    ]\n];"
-        );
-
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getName()->willReturn('some/component');
-        $package->getExtra()->willReturn([
-            'laminas' => [
-                'component' => 'Some\\Component',
-            ],
-        ]);
-        $package->getAutoload()->willReturn([]);
-
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
-
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
-
-        $this->io
-            ->write('<info>    Removing Some\Component from package some/component</info>')
-            ->shouldBeCalled();
-
-        $this->io
-            ->write(Argument::that(function ($argument) {
-                return (bool) preg_match(
-                    '#Removed package from .*?config/application.config.php#',
-                    $argument
-                );
-            }))
-            ->shouldBeCalled();
-
-        $this->installer->onPostPackageUninstall($event->reveal());
-
-        $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
-        $this->assertStringNotContainsString('Some\Component', $config);
-    }
-
-    public function testOnPostPackageUninstallCanRemovePackageArraysFromConfiguration(): void
-    {
-        $this->createApplicationConfig(
-            '<' . "?php\nreturn [\n    'modules' => [\n        'Some\Component',\n    'Other\Component',\n    ]\n];"
-        );
-
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getName()->willReturn('some/component');
-        $package->getExtra()->willReturn([
-            'laminas' => [
-                'component' => [
-                    'Some\\Component',
-                    'Other\\Component',
-                ],
-            ],
-        ]);
-        $package->getAutoload()->willReturn([]);
-
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
-
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
-
-        $this->rootPackage->getRequires()->willReturn([]);
-
-        $this->io
-            ->write('<info>    Removing Some\Component from package some/component</info>')
-            ->shouldBeCalled();
-        $this->io
-            ->write('<info>    Removing Other\Component from package some/component</info>')
-            ->shouldBeCalled();
-
-        $this->io
-            ->write(Argument::that(function ($argument) {
-                return (bool) preg_match(
-                    '#Removed package from .*?config/application.config.php#',
-                    $argument
-                );
-            }))
-            ->shouldBeCalled();
-
-        $this->installer->onPostPackageUninstall($event->reveal());
-
-        $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
-        $this->assertStringNotContainsString('Some\Component', $config);
-        $this->assertStringNotContainsString('Other\Component', $config);
-    }
-
-    public function testModuleIsAppended(): void
-    {
-        $this->createApplicationConfig(
-            '<' . "?php\nreturn [\n    'modules' => [\n        'Some\Component',\n    ]\n];"
-        );
-
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getName()->willReturn('some/module');
-        $package->getExtra()->willReturn([
-            'laminas' => [
-                'module' => 'Some\\Module',
-            ],
-        ]);
-        $package->getAutoload()->willReturn([]);
-
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
-
-        /** @psalm-var PackageEvent&ObjectProphecy $event */
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
-        $this->prepareEventForPackageProviderDetection($event, 'some/module');
-
-        $this->rootPackage->getRequires()->willReturn([]);
-        $this->rootPackage->getName()->willReturn('some/module');
-
-        $this->io->ask(Argument::that(function ($argument) {
-            if (! is_string($argument)) {
-                return false;
-            }
-
-            if (
-                false === strpos(
-                    $argument,
-                    "Please select which config file you wish to inject 'Some\Module' into"
-                )
-            ) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'Do not inject')) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'application.config.php')) {
-                return false;
-            }
-
-            return true;
-        }), 1)->willReturn(1);
-
-        $this->io->ask(Argument::that(function ($argument) {
-            if (! is_string($argument)) {
-                return false;
-            }
-            if (false === strpos($argument, 'Remember')) {
-                return false;
-            }
-
-            return true;
-        }), 'y')->willReturn('y');
-
-        $this->io->write(Argument::that(function ($argument) {
-            return strstr($argument, 'Installing Some\Module from package some/module');
-        }))->shouldBeCalled();
-
-        $this->installer->onPostPackageInstall($event->reveal());
-        $config = include vfsStream::url('project/config/application.config.php');
+        $this->installer->onPostPackageInstall($event);
+        /** @psalm-suppress UnresolvableInclude */
+        $config = require vfsStream::url('project/config/application.config.php');
+        Assert::isNonEmptyMap($config);
+        Assert::keyExists($config, 'modules');
+        Assert::isNonEmptyList($config['modules']);
         $modules = $config['modules'];
-        $this->assertEquals([
+        self::assertEquals([
             'Some\Component',
             'Some\Module',
         ], $modules);
@@ -1497,210 +959,43 @@ CONTENT
             '<' . "?php\nreturn [\n    'modules' => [\n        'SomeApplication',\n    ]\n];"
         );
 
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getAutoload()->willReturn([]);
-        $package->getName()->willReturn('some/package');
-        $package->getExtra()->willReturn([
+        $package = $this->createMock(PackageInterface::class);
+        $package->method('getName')->willReturn('some/package');
+        $package->method('getExtra')->willReturn([
             'laminas' => [
                 'module'    => 'Some\\Module',
                 'component' => 'Some\\Component',
             ],
         ]);
 
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
+        $operation = $this->createMock(InstallOperation::class);
+        $operation->method('getPackage')->willReturn($package);
 
-        /** @psalm-var PackageEvent&ObjectProphecy $event */
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
+        $event = $this->createMock(PackageEvent::class);
+        $event->method('isDevMode')->willReturn(true);
+        $event->method('getOperation')->willReturn($operation);
         $this->prepareEventForPackageProviderDetection($event, 'some/package');
 
-        $this->rootPackage->getRequires()->willReturn([]);
-        $this->rootPackage->getName()->willReturn('some/package');
+        $this->rootPackage->method('getName')->willReturn('some/package');
 
-        $this->io->ask(Argument::that(function ($argument) {
-            if (! is_string($argument)) {
-                return false;
-            }
-
-            if (
-                false === strpos(
-                    $argument,
-                    "Please select which config file you wish to inject 'Some\Module' into"
-                )
-            ) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'Do not inject')) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'application.config.php')) {
-                return false;
-            }
-
-            return true;
-        }), 1)->willReturn(1);
-
-        $this->io->ask(Argument::that(function ($argument) {
-            if (! is_string($argument)) {
-                return false;
-            }
-
-            if (
-                false === strpos(
-                    $argument,
-                    "Please select which config file you wish to inject 'Some\Component' into"
-                )
-            ) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'Do not inject')) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'application.config.php')) {
-                return false;
-            }
-
-            return true;
-        }), 1)->willReturn(1);
-
-        $this->io->ask(Argument::that(function ($argument) {
-            if (! is_string($argument)) {
-                return false;
-            }
-            if (false === strpos($argument, 'Remember')) {
-                return false;
-            }
-
-            return true;
-        }), 'y')->willReturn('n');
-
-        $this->io->write(Argument::that(function ($argument) {
-            return strstr($argument, 'Installing Some\Module from package some/package');
-        }))->shouldBeCalled();
-
-        $this->io->write(Argument::that(function ($argument) {
-            return strstr($argument, 'Installing Some\Component from package some/package');
-        }))->shouldBeCalled();
-
-        $this->installer->onPostPackageInstall($event->reveal());
-        $config = include vfsStream::url('project/config/application.config.php');
-        $modules = $config['modules'];
-        $this->assertEquals([
-            'Some\Component',
-            'SomeApplication',
-            'Some\Module',
-        ], $modules);
-    }
-
-    public function testPrependComponentAndAppendModule(): void
-    {
-        $this->createApplicationConfig(
-            '<' . "?php\nreturn [\n    'modules' => [\n        'SomeApplication',\n    ]\n];"
-        );
-
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getAutoload()->willReturn([]);
-        $package->getName()->willReturn('some/package');
-        $package->getExtra()->willReturn([
-            'laminas' => [
-                'component' => 'Some\\Component',
-                'module'    => 'Some\\Module',
-            ],
+        $this->createInputAssertions([
+            RememberedAnswerQuestionAssertion::inject('Some\Component', 1, false),
+            RememberedAnswerQuestionAssertion::inject('Some\Module', 1, false),
         ]);
 
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
+        $this->createOutputAssertions([
+            'Installing Some\Component from package some/package',
+            'Installing Some\Module from package some/package',
+        ]);
 
-        /** @psalm-var PackageEvent&ObjectProphecy $event */
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
-        $this->prepareEventForPackageProviderDetection($event, 'some/package');
-
-        $this->rootPackage->getRequires()->willReturn([]);
-        $this->rootPackage
-            ->getName()
-            ->willReturn('some/package');
-
-        $this->io->ask(Argument::that(function ($argument) {
-            if (! is_string($argument)) {
-                return false;
-            }
-
-            if (
-                false === strpos(
-                    $argument,
-                    "Please select which config file you wish to inject 'Some\Module' into"
-                )
-            ) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'Do not inject')) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'application.config.php')) {
-                return false;
-            }
-
-            return true;
-        }), 1)->willReturn(1);
-
-        $this->io->ask(Argument::that(function ($argument) {
-            if (! is_string($argument)) {
-                return false;
-            }
-
-            if (
-                false === strpos(
-                    $argument,
-                    "Please select which config file you wish to inject 'Some\Component' into"
-                )
-            ) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'Do not inject')) {
-                return false;
-            }
-
-            if (false === strpos($argument, 'application.config.php')) {
-                return false;
-            }
-
-            return true;
-        }), 1)->willReturn(1);
-
-        $this->io->ask(Argument::that(function ($argument) {
-            if (! is_string($argument)) {
-                return false;
-            }
-            if (false === strpos($argument, 'Remember')) {
-                return false;
-            }
-
-            return true;
-        }), 'y')->willReturn('n');
-
-        $this->io->write(Argument::that(function ($argument) {
-            return strstr($argument, 'Installing Some\Module from package some/package');
-        }))->shouldBeCalled();
-
-        $this->io->write(Argument::that(function ($argument) {
-            return strstr($argument, 'Installing Some\Component from package some/package');
-        }))->shouldBeCalled();
-
-        $this->installer->onPostPackageInstall($event->reveal());
-        $config = include vfsStream::url('project/config/application.config.php');
+        $this->installer->onPostPackageInstall($event);
+        /** @psalm-suppress UnresolvableInclude */
+        $config = require vfsStream::url('project/config/application.config.php');
+        Assert::isNonEmptyMap($config);
+        Assert::keyExists($config, 'modules');
+        Assert::isNonEmptyList($config['modules']);
         $modules = $config['modules'];
-        $this->assertEquals([
+        self::assertEquals([
             'Some\Component',
             'SomeApplication',
             'Some\Module',
@@ -1736,7 +1031,7 @@ CONTENT
 
         $dependencies = $rm->invoke($this->installer, $file);
 
-        $this->assertEquals($result, $dependencies);
+        self::assertEquals($result, $dependencies);
     }
 
     public function testGetModuleClassesDependenciesHandlesAutoloadersWithMultiplePathsMappedToSameNamespace(): void
@@ -1767,19 +1062,20 @@ CONTENT
             ],
         ];
 
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getAutoload()->willReturn($autoloaders);
+        $package = $this->createMock(PackageInterface::class);
+        $package->method('getAutoload')->willReturn($autoloaders);
 
         $this->installationManager
-            ->getInstallPath(Argument::that([$package, 'reveal']))
+            ->method('getInstallPath')
+            ->with($package)
             ->willReturn(vfsStream::url('project/' . $installPath));
 
         $r  = new ReflectionObject($this->installer);
         $rm = $r->getMethod('loadModuleClassesDependencies');
         $rm->setAccessible(true);
 
-        $dependencies = $rm->invoke($this->installer, $package->reveal());
-        $this->assertEquals([
+        $dependencies = $rm->invoke($this->installer, $package);
+        self::assertEquals([
             'DoesNotExist'       => ['DoesNotExistDependency'],
             'DoesNotExistEither' => ['DoesNotExistEitherDependency'],
             'ClassmappedToo'     => ['ClassmappedTooDependency'],
@@ -1867,41 +1163,30 @@ CONTENT
             $this->createConfigFile($configName, $configContents);
         }
 
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getName()->willReturn('some/component');
-        $package->getExtra()->willReturn([
+        $package = $this->createMock(PackageInterface::class);
+        $package->method('getName')->willReturn('some/component');
+        $package->method('getExtra')->willReturn([
             'laminas' => [
                 'component' => [
                     'Some\\Component',
                 ],
             ],
         ]);
-        $package->getAutoload()->willReturn([]);
 
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
+        $operation = $this->createMock(UninstallOperation::class);
+        $operation->method('getPackage')->willReturn($package);
 
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
+        $event = $this->createMock(PackageEvent::class);
+        $event->method('isDevMode')->willReturn(true);
+        $event->method('getOperation')->willReturn($operation);
 
-        $this->rootPackage->getRequires()->willReturn([]);
 
-        $this->io
-            ->write('<info>    Removing Some\Component from package some/component</info>')
-            ->shouldBeCalled();
+        $this->createOutputAssertions([
+            '<info>    Removing Some\Component from package some/component</info>',
+            sprintf('Removed package from %s', $expectedName)
+        ]);
 
-        // assertion
-        $this->io
-            ->write(Argument::that(function ($argument) use ($expectedName) {
-                return (bool) preg_match(
-                    sprintf('#Removed package from %s#', $expectedName),
-                    $argument
-                );
-            }))
-            ->shouldBeCalled();
-
-        $this->installer->onPostPackageUninstall($event->reveal());
+        $this->installer->onPostPackageUninstall($event);
     }
 
     public function testInstallWhitelistedDevModuleWithDifferentInjectors(): void
@@ -1930,48 +1215,52 @@ CONFIG;
             $this->createConfigFile($configName, $configContents);
         }
 
-        $this->rootPackage->getDevRequires()->willReturn(['some/component' => '*']);
-        $this->rootPackage->getExtra()->willReturn([
-            'laminas' => [
-                "component-whitelist" => [
-                    "some/component",
-                ],
-            ],
-        ]);
+        $this->rootPackage->method('getDevRequires')->willReturn(['some/component' => '*']);
+        $this->rootPackageExtra = [
+           'laminas' => [
+               "component-whitelist" => [
+                   "some/component",
+               ]
+           ]
+        ];
 
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getName()->willReturn('some/component');
-        $package->getExtra()->willReturn([
+        $package = $this->createMock(PackageInterface::class);
+        $package->method('getName')->willReturn('some/component');
+        $package->method('getExtra')->willReturn([
             'laminas' => [
                 'component' => [
                     'Some\\Component',
                 ],
             ],
         ]);
-        $package->getAutoload()->willReturn([]);
 
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
+        $operation = $this->createMock(InstallOperation::class);
+        $operation->method('getPackage')->willReturn($package);
 
-        /** @psalm-var PackageEvent&ObjectProphecy $event */
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
+        $event = $this->createMock(PackageEvent::class);
+        $event->method('isDevMode')->willReturn(true);
+        $event->method('getOperation')->willReturn($operation);
         $this->prepareEventForPackageProviderDetection($event, 'some/component');
 
-        $this->rootPackage->getRequires()->willReturn([]);
-
-        $this->installer->onPostPackageInstall($event->reveal());
-        $config = include vfsStream::url('project/config/modules.config.php');
+        $this->installer->onPostPackageInstall($event);
+        /** @psalm-suppress UnresolvableInclude */
+        $config = require vfsStream::url('project/config/modules.config.php');
+        Assert::isNonEmptyMap($config);
+        Assert::keyExists($config, 'modules');
+        Assert::isNonEmptyList($config['modules']);
         $modules = $config['modules'];
-        $this->assertEquals([
+        self::assertEquals([
             'Laminas\Router',
             'Laminas\Validator',
             'Application',
         ], $modules);
-        $config  = include vfsStream::url('project/config/development.config.php');
+        /** @psalm-suppress UnresolvableInclude */
+        $config = require vfsStream::url('project/config/development.config.php');
+        Assert::isNonEmptyMap($config);
+        Assert::keyExists($config, 'modules');
+        Assert::isNonEmptyList($config['modules']);
         $modules = $config['modules'];
-        $this->assertEquals(['Some\Component'], $modules);
+        self::assertEquals(['Some\Component'], $modules);
     }
 
     public function testInstallWhitelistedDevModuleWithUniqueInjector(): void
@@ -1989,41 +1278,42 @@ CONFIG;
 
         $this->createConfigFile('modules.config.php', $moduleConfigContent);
 
-        $this->rootPackage->getExtra()->willReturn([
-            'laminas' => [
-                "component-whitelist" => [
-                    "some/module",
-                ],
-            ],
-        ]);
+        $this->rootPackageExtra = [
+           'laminas' => [
+               "component-whitelist" => [
+                   "some/module",
+               ],
+           ],
+        ];
 
-        $package = $this->prophesize(PackageInterface::class);
-        $package->getName()->willReturn('some/module');
-        $package->getExtra()->willReturn([
+        $package = $this->createMock(PackageInterface::class);
+        $package->method('getName')->willReturn('some/module');
+        $package->method('getExtra')->willReturn([
             'laminas' => [
                 'module' => 'Some\\Module',
             ],
         ]);
-        $package->getAutoload()->willReturn([]);
 
-        $operation = $this->prophesize(InstallOperation::class);
-        $operation->getPackage()->willReturn($package->reveal());
+        $operation = $this->createMock(InstallOperation::class);
+        $operation->method('getPackage')->willReturn($package);
 
-        /** @psalm-var PackageEvent&ObjectProphecy $event */
-        $event = $this->prophesize(PackageEvent::class);
-        $event->isDevMode()->willReturn(true);
-        $event->getOperation()->willReturn($operation->reveal());
+        $event = $this->createMock(PackageEvent::class);
+        $event->method('isDevMode')->willReturn(true);
+        $event->method('getOperation')->willReturn($operation);
         $this->prepareEventForPackageProviderDetection($event, 'some/module');
 
         $this->rootPackage
-            ->getName()
+            ->method('getName')
             ->willReturn('some/module');
-        $this->rootPackage->getRequires()->willReturn([]);
 
-        $this->installer->onPostPackageInstall($event->reveal());
-        $config = include vfsStream::url('project/config/modules.config.php');
+        $this->installer->onPostPackageInstall($event);
+        /** @psalm-suppress UnresolvableInclude */
+        $config = require vfsStream::url('project/config/modules.config.php');
+        Assert::isNonEmptyMap($config);
+        Assert::keyExists($config, 'modules');
+        Assert::isNonEmptyList($config['modules']);
         $modules = $config['modules'];
-        $this->assertEquals([
+        self::assertEquals([
             'Laminas\Router',
             'Laminas\Validator',
             'Application',
@@ -2073,15 +1363,65 @@ CONFIG;
     }
 
     /**
-     * @param PackageEvent|ObjectProphecy $event
-     * @psalm-param PackageEvent&ObjectProphecy $event
+     * @param PackageEvent|MockObject $event
+     * @psalm-param PackageEvent&MockObject $event
      */
     private function prepareEventForPackageProviderDetection($event, string $packageName): void
     {
         if (method_exists(PackageEvent::class, 'getPool')) {
-            $pool = $this->prophesize(Pool::class);
-            $pool->whatProvides($packageName)->willReturn([]);
-            $event->getPool()->willReturn($pool->reveal());
+            $pool = $this->createMock(Pool::class);
+            $pool->method('whatProvides')->with($packageName)->willReturn([]);
+            $event->method('getPool')->willReturn($pool);
         }
+    }
+
+    /**
+     * @param array<int,string> $informations
+     */
+    private function createOutputAssertions(array $informations): void
+    {
+        $consecutiveArguments = [];
+
+        foreach ($informations as $information) {
+            $consecutiveArguments[] = [
+                self::callback(static function (string $argument) use ($information): bool {
+                    return preg_match(
+                        sprintf('/%s/', preg_quote($argument, '/')),
+                        $information
+                    ) !== false;
+                })
+            ];
+        }
+
+        $this->io
+            ->expects(self::exactly(count($consecutiveArguments)))
+            ->method('write')
+            ->withConsecutive(...$consecutiveArguments);
+    }
+
+    /**
+     * @param array<int,AbstractQuestionAssertion> $questionsAssertions
+     */
+    private function createInputAssertions(array $questionsAssertions): void
+    {
+        $consecutiveReturnValues = $consecutiveArguments = [];
+        foreach ($questionsAssertions as $questionAssertion) {
+            /** @psalm-suppress MissingClosureParamType */
+            $consecutiveArguments[] = [
+                self::callback($questionAssertion->assertion())
+            ];
+            $consecutiveReturnValues[] = $questionAssertion->expectedAnswer;
+
+            if ($questionAssertion instanceof RememberedAnswerQuestionAssertion) {
+                $consecutiveArguments[] = [self::callback($questionAssertion->rememberAnswerAssertion())];
+                $consecutiveReturnValues[] = $questionAssertion->remember ? 'y' : 'n';
+            }
+        }
+
+        $this->io
+            ->expects(self::exactly(count($consecutiveArguments)))
+            ->method('ask')
+            ->withConsecutive(...$consecutiveArguments)
+            ->willReturnOnConsecutiveCalls(...$consecutiveReturnValues);
     }
 }

--- a/test/RememberedAnswerQuestionAssertion.php
+++ b/test/RememberedAnswerQuestionAssertion.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * @see       https://github.com/laminas/laminas-component-installer for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-component-installer/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-component-installer/blob/master/LICENSE.md New BSD License
+ */
+
 declare(strict_types=1);
 
 namespace LaminasTest\ComponentInstaller;

--- a/test/RememberedAnswerQuestionAssertion.php
+++ b/test/RememberedAnswerQuestionAssertion.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace LaminasTest\ComponentInstaller;
+
+use function sprintf;
+
+/**
+ * @psalm-immutable
+ */
+final class RememberedAnswerQuestionAssertion extends AbstractQuestionAssertion
+{
+    private const REMEMBER_QUESTION = 'Remember this option for other packages of the same type';
+
+    /**
+     * @var bool
+     */
+    public $remember;
+
+    /**
+     * @psalm-param non-empty-string $expectedQuestion
+     * @psalm-param scalar           $expectedAnswer
+     */
+    private function __construct(string $expectedQuestion, $expectedAnswer, bool $remember)
+    {
+        parent::__construct($expectedQuestion, $expectedAnswer);
+        $this->remember = $remember;
+    }
+
+
+    /**
+     * @psalm-param non-empty-string $question
+     * @psalm-param scalar           $answer
+     */
+    public static function create(string $question, $answer, bool $remember): self
+    {
+        return new self($question, $answer, $remember);
+    }
+
+    public static function inject(string $component, int $chosen, bool $remember): self
+    {
+        $question = sprintf('Please select which config file you wish to inject \'%s\' into', $component);
+        assert($question !== '');
+        return self::create(
+            $question,
+            $chosen,
+            $remember
+        );
+    }
+
+    /**
+     * @return callable(mixed):bool
+     */
+    public function rememberAnswerAssertion(): callable
+    {
+        return static function (string $question): bool {
+            return strpos($question, self::REMEMBER_QUESTION) !== false;
+        };
+    }
+}

--- a/test/RememberedAnswerQuestionAssertion.php
+++ b/test/RememberedAnswerQuestionAssertion.php
@@ -1,9 +1,12 @@
 <?php
+
 declare(strict_types=1);
 
 namespace LaminasTest\ComponentInstaller;
 
+use function assert;
 use function sprintf;
+use function strpos;
 
 /**
  * @psalm-immutable
@@ -12,9 +15,7 @@ final class RememberedAnswerQuestionAssertion extends AbstractQuestionAssertion
 {
     private const REMEMBER_QUESTION = 'Remember this option for other packages of the same type';
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     public $remember;
 
     /**
@@ -26,7 +27,6 @@ final class RememberedAnswerQuestionAssertion extends AbstractQuestionAssertion
         parent::__construct($expectedQuestion, $expectedAnswer);
         $this->remember = $remember;
     }
-
 
     /**
      * @psalm-param non-empty-string $question

--- a/test/TestAsset/NativeTypehintedInstallationManager.php
+++ b/test/TestAsset/NativeTypehintedInstallationManager.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace LaminasTest\ComponentInstaller\TestAsset;
+
+use Composer\Installer\InstallationManager;
+use Composer\Package\PackageInterface;
+
+/**
+ * Class to ensure we do not have to mock each of these methods in every unit test.
+ * PHPUnit will create return values based on the native typehint.
+ */
+class NativeTypehintedInstallationManager extends InstallationManager
+{
+    public function getInstallPath(PackageInterface $package): string
+    {
+        return parent::getInstallPath($package);
+    }
+}

--- a/test/TestAsset/NativeTypehintedInstallationManager.php
+++ b/test/TestAsset/NativeTypehintedInstallationManager.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * @see       https://github.com/laminas/laminas-component-installer for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-component-installer/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-component-installer/blob/master/LICENSE.md New BSD License
+ */
+
 declare(strict_types=1);
 
 namespace LaminasTest\ComponentInstaller\TestAsset;

--- a/test/TestAsset/NativeTypehintedInstallationManager.php
+++ b/test/TestAsset/NativeTypehintedInstallationManager.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace LaminasTest\ComponentInstaller\TestAsset;

--- a/test/TestAsset/NativeTypehintedPackageInterface.php
+++ b/test/TestAsset/NativeTypehintedPackageInterface.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * @see       https://github.com/laminas/laminas-component-installer for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-component-installer/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-component-installer/blob/master/LICENSE.md New BSD License
+ */
+
 declare(strict_types=1);
 
 namespace LaminasTest\ComponentInstaller\TestAsset;

--- a/test/TestAsset/NativeTypehintedPackageInterface.php
+++ b/test/TestAsset/NativeTypehintedPackageInterface.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace LaminasTest\ComponentInstaller\TestAsset;
+
+use Composer\Package\PackageInterface;
+
+/**
+ * Interface to ensure we do not have to mock each of these methods in every unit test.
+ * PHPUnit will create return values based on the native typehint.
+ */
+interface NativeTypehintedPackageInterface extends PackageInterface
+{
+    public function getAutoload(): array;
+    public function getName(): string;
+    public function getExtra(): array;
+    public function getProvides(): array;
+    public function getReplaces(): array;
+    public function getRequires(): array;
+    public function getDevRequires(): array;
+    public function getDevAutoload(): array;
+}

--- a/test/TestAsset/NativeTypehintedPackageInterface.php
+++ b/test/TestAsset/NativeTypehintedPackageInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace LaminasTest\ComponentInstaller\TestAsset;
@@ -12,11 +13,18 @@ use Composer\Package\PackageInterface;
 interface NativeTypehintedPackageInterface extends PackageInterface
 {
     public function getAutoload(): array;
+
     public function getName(): string;
+
     public function getExtra(): array;
+
     public function getProvides(): array;
+
     public function getReplaces(): array;
+
     public function getRequires(): array;
+
     public function getDevRequires(): array;
+
     public function getDevAutoload(): array;
 }

--- a/test/TestAsset/NativeTypehintedRootPackageInterface.php
+++ b/test/TestAsset/NativeTypehintedRootPackageInterface.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * @see       https://github.com/laminas/laminas-component-installer for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-component-installer/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-component-installer/blob/master/LICENSE.md New BSD License
+ */
+
 declare(strict_types=1);
 
 namespace LaminasTest\ComponentInstaller\TestAsset;

--- a/test/TestAsset/NativeTypehintedRootPackageInterface.php
+++ b/test/TestAsset/NativeTypehintedRootPackageInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace LaminasTest\ComponentInstaller\TestAsset;
@@ -8,11 +9,18 @@ use Composer\Package\RootPackageInterface;
 interface NativeTypehintedRootPackageInterface extends RootPackageInterface
 {
     public function getAutoload(): array;
+
     public function getName(): string;
+
     public function getExtra(): array;
+
     public function getProvides(): array;
+
     public function getReplaces(): array;
+
     public function getRequires(): array;
+
     public function getDevRequires(): array;
+
     public function getDevAutoload(): array;
 }

--- a/test/TestAsset/NativeTypehintedRootPackageInterface.php
+++ b/test/TestAsset/NativeTypehintedRootPackageInterface.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace LaminasTest\ComponentInstaller\TestAsset;
+
+use Composer\Package\RootPackageInterface;
+
+interface NativeTypehintedRootPackageInterface extends RootPackageInterface
+{
+    public function getAutoload(): array;
+    public function getName(): string;
+    public function getExtra(): array;
+    public function getProvides(): array;
+    public function getReplaces(): array;
+    public function getRequires(): array;
+    public function getDevRequires(): array;
+    public function getDevAutoload(): array;
+}


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

I am currently working on a PoC for #10 and thus want to write tests.
As prophecy drives me crazy, I've replaced it with native mocks. So there are unrelated changes in the `ComponentInstaller` as I've already added that private `addPackageToConfig` method for my PoC of #10.

