### PR TITLE
Add type cast to prevent deprecated passing of null value to is_dir

### DIFF
--- a/src/ConfigDiscovery/AbstractDiscovery.php
+++ b/src/ConfigDiscovery/AbstractDiscovery.php
@@ -38,7 +38,7 @@ abstract class AbstractDiscovery implements DiscoveryInterface
      */
     public function __construct($projectDirectory = '')
     {
-        if ('' !== $projectDirectory && is_dir($projectDirectory)) {
+        if ('' !== (string) $projectDirectory && is_dir($projectDirectory)) {
             $this->configFile = sprintf(
                 '%s/%s',
                 $projectDirectory,

--- a/test/ConfigDiscovery/AbstractDiscoveryTest.php
+++ b/test/ConfigDiscovery/AbstractDiscoveryTest.php
@@ -12,7 +12,7 @@ class AbstractDiscoveryTest extends TestCase
     /**
      * @covers \Laminas\ComponentInstaller\ConfigDiscovery\AbstractDiscovery::__construct
      */
-    public function testConstructorThrowsExceptionWithProjectDirectoryOfNull(): void
+    public function testConstructorAcceptsNullValueForProjectDirectory(): void
     {
         $this->expectNotToPerformAssertions();
         new class extends AbstractDiscovery {

--- a/test/ConfigDiscovery/AbstractDiscoveryTest.php
+++ b/test/ConfigDiscovery/AbstractDiscoveryTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\ComponentInstaller\ConfigDiscovery;
+
+use Laminas\ComponentInstaller\ConfigDiscovery\AbstractDiscovery;
+use PHPUnit\Framework\TestCase;
+
+class AbstractDiscoveryTest extends TestCase
+{
+    /**
+     * @covers \Laminas\ComponentInstaller\ConfigDiscovery\AbstractDiscovery::__construct
+     */
+    public function testConstructorThrowsExceptionWithProjectDirectoryOfNull(): void
+    {
+        $this->expectNotToPerformAssertions();
+        new class extends AbstractDiscovery {
+            public function __construct()
+            {
+                parent::__construct(null);
+            }
+        };
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|----------- | ------
| QA            | yes

### Description

This fixes the deprecated call of `is_dir` with a null value by casting input value for strict comparison with empty string.

See #36.