### PR TITLE
Remove mentioning of deprecated mezzio-config-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ one or more of the following keys under the `extra.laminas` configuration in the
   - `config/development.config.php`
 
 - A **config-provider** is for use with applications that utilize
-  [mezzio-config-manager](https://github.com/mtymek/mezzio-config-manager)
-  or [laminas-config-aggregator](https://github.com/laminas/laminas-config-aggregator)
+  [laminas-config-aggregator](https://github.com/laminas/laminas-config-aggregator)
   (which may or may not be Mezzio applications). The class listed must be an
   invokable that returns an array of configuration, and will be injected at the
   top of:


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes/no

### Description

The original package [mtymek/expressive-config-manager](https://github.com/mtymek/expressive-config-manager/) is deprecated and was merged to [zendframework/zend-config-aggregator](https://github.com/zendframework/zend-config-aggregator) and finally moved to [laminas/laminas-config-aggregator](https://github.com/laminas/laminas-config-aggregator).

The package (mezzio-config-manager) was falsely renamed during [Rewriting as Laminas Project package](https://github.com/laminas/laminas-component-installer/commit/76e16eefe82873b99654a1ea5f7ddc8908985ba2#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R61) and since a dead link.

Since essentially the same package is referenced twice, the dead link is removed instead of replaced.

