### PR TITLE
Remove composer `RootPackage` state pollution

### DIFF
--- a/src/PackageProvider/PackageProviderDetectionFactory.php
+++ b/src/PackageProvider/PackageProviderDetectionFactory.php
@@ -14,7 +14,6 @@ use Composer\Repository\InstalledRepository;
 use Composer\Repository\PlatformRepository;
 use Composer\Repository\RepositoryFactory;
 use Composer\Repository\RepositoryInterface;
-use Composer\Repository\RepositoryInterface as ComposerRepositoryInterface;
 use Composer\Repository\RootPackageRepository;
 
 use function method_exists;
@@ -25,12 +24,10 @@ use function method_exists;
 final class PackageProviderDetectionFactory implements PackageProviderDetectionFactoryInterface
 {
     private Composer $composer;
-    private RootPackageRepository $packageRepository;
 
     public function __construct(Composer $composer)
     {
-        $this->composer          = $composer;
-        $this->packageRepository = new RootPackageRepository($composer->getPackage());
+        $this->composer = $composer;
     }
 
     public static function create(Composer $composer): self
@@ -54,15 +51,18 @@ final class PackageProviderDetectionFactory implements PackageProviderDetectionF
     }
 
     /**
-     * @return list<ComposerRepositoryInterface>
+     * @return list<RepositoryInterface>
      */
     private function prepareRepositoriesForInstalledRepository(): array
     {
         /** @var array<string,string|false> $platformOverrides */
         $platformOverrides = $this->composer->getConfig()->get('platform') ?? [];
 
+        $rootPackage           = $this->composer->getPackage();
+        $rootPackageRepository = $rootPackage->getRepository() ?? new RootPackageRepository(clone $rootPackage);
+
         return [
-            $this->packageRepository,
+            $rootPackageRepository,
             $this->composer->getRepositoryManager()->getLocalRepository(),
             new PlatformRepository([], $platformOverrides),
         ];

--- a/test/ComponentInstallerTest.php
+++ b/test/ComponentInstallerTest.php
@@ -1950,6 +1950,19 @@ CONFIG;
         self::assertEquals($expectedInstalledModules, $modules);
     }
 
+    public function testDoesNotModifyRootPackageOnPluginActivation(): void
+    {
+        $installer = new ComponentInstaller(
+            vfsStream::url('project')
+        );
+
+        $rootPackage = new RootPackage('vendor/package', '1.0.0', '1.0.0');
+
+        $composer = $this->createComposerMock(null, $rootPackage);
+        $installer->activate($composer, $this->io);
+        self::assertNull($rootPackage->getRepository());
+    }
+
     /**
      * @psalm-return Generator<non-empty-string,array{
      *     0:list<non-empty-string>,

--- a/test/PackageProvider/PackageProviderDetectionFactoryTest.php
+++ b/test/PackageProvider/PackageProviderDetectionFactoryTest.php
@@ -42,6 +42,18 @@ final class PackageProviderDetectionFactoryTest extends TestCase
         $packageProvider->whatProvides('some/component');
     }
 
+    public function testUsesRootPackageCloneWhenCreatingRootPackageRepository(): void
+    {
+        $rootPackage = new RootPackage('some/component', '1.0.0', '1.0.0');
+        $composer    = $this->createComposerMock($rootPackage);
+
+        $factory = new PackageProviderDetectionFactory($composer);
+        $event   = $this->createMock(PackageEvent::class);
+
+        $factory->detect($event, 'some/component');
+        self::assertNull($rootPackage->getRepository());
+    }
+
     /**
      * @return Composer&MockObject
      */

--- a/test/PackageProvider/PackageProviderDetectionFactoryTest.php
+++ b/test/PackageProvider/PackageProviderDetectionFactoryTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\ComponentInstaller\PackageProvider;
+
+use Composer\Composer;
+use Composer\Installer\PackageEvent;
+use Composer\Package\RootPackage;
+use Composer\Repository\InstalledRepositoryInterface;
+use Composer\Repository\RepositoryManager;
+use Composer\Repository\RootPackageRepository;
+use Laminas\ComponentInstaller\PackageProvider\PackageProviderDetectionFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class PackageProviderDetectionFactoryTest extends TestCase
+{
+    public function testUsesRootPackageRepositoryFromRootPackageIfExists(): void
+    {
+        $rootPackage = $this->createMock(RootPackage::class);
+        $composer    = $this->createComposerMock($rootPackage);
+
+        $repository = $this->createMock(RootPackageRepository::class);
+
+        $rootPackage
+            ->expects(self::once())
+            ->method('getRepository')
+            ->willReturn($repository);
+
+        $factory = new PackageProviderDetectionFactory($composer);
+        $event   = $this->createMock(PackageEvent::class);
+
+        $packageProvider = $factory->detect($event, 'some/component');
+
+        // Lets verify that this method is definitely called when we are calling PackageProviderDetection#whatProvides
+        $repository
+            ->expects(self::once())
+            ->method('getPackages')
+            ->willReturn([]);
+
+        $packageProvider->whatProvides('some/component');
+    }
+
+    /**
+     * @return Composer&MockObject
+     */
+    private function createComposerMock(
+        ?RootPackage $package = null
+    ): Composer {
+        $composer = $this->createMock(Composer::class);
+
+        $package ??= $this->createMock(RootPackage::class);
+
+        $composer
+            ->method('getPackage')
+            ->willReturn($package);
+
+        $installedRepository = $this->createMock(InstalledRepositoryInterface::class);
+        $installedRepository
+            ->method('getPackages')
+            ->willReturn([]);
+
+        $repositoryManager = $this->createMock(RepositoryManager::class);
+        $repositoryManager
+            ->method('getLocalRepository')
+            ->willReturn($installedRepository);
+
+        $composer
+            ->method('getRepositoryManager')
+            ->willReturn($repositoryManager);
+
+        return $composer;
+    }
+}


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

In v3.0.0, we remove the "lazy" initialisation of the plugin. 
This pointed out, that we polluted the `RootPackage` within the `Composer` instance by initialising the `RootPackageRepository` (which internally passes itself to the `RootPackage`).

In https://github.com/composer/composer/commit/b195f383f2474cb0ec68bead4467079bfd136f60, composer also added `clone` in all commands so that the issue will be fixed for projects with v3.0.0 but we should still fix the pollution in the next patch release.

Fixes #57 
