### PR TITLE
Fix type error when trying to discover module dependencies for metapackages

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -324,23 +324,23 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.4.4",
+            "version": "2.5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "e8d9087229bcdbc5867594d3098091412f1130cf"
+                "reference": "d477018d3f2ebd76dede3d3988a0b1a7add4d81e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/e8d9087229bcdbc5867594d3098091412f1130cf",
-                "reference": "e8d9087229bcdbc5867594d3098091412f1130cf",
+                "url": "https://api.github.com/repos/composer/composer/zipball/d477018d3f2ebd76dede3d3988a0b1a7add4d81e",
+                "reference": "d477018d3f2ebd76dede3d3988a0b1a7add4d81e",
                 "shasum": ""
             },
             "require": {
                 "composer/ca-bundle": "^1.0",
                 "composer/class-map-generator": "^1.0",
                 "composer/metadata-minifier": "^1.0",
-                "composer/pcre": "^2 || ^3",
+                "composer/pcre": "^2.1 || ^3.1",
                 "composer/semver": "^3.0",
                 "composer/spdx-licenses": "^1.5.7",
                 "composer/xdebug-handler": "^2.0.2 || ^3.0.3",
@@ -356,10 +356,11 @@
                 "symfony/finder": "^5.4 || ^6.0",
                 "symfony/polyfill-php73": "^1.24",
                 "symfony/polyfill-php80": "^1.24",
+                "symfony/polyfill-php81": "^1.24",
                 "symfony/process": "^5.4 || ^6.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.4.1",
+                "phpstan/phpstan": "^1.9.3",
                 "phpstan/phpstan-deprecation-rules": "^1",
                 "phpstan/phpstan-phpunit": "^1.0",
                 "phpstan/phpstan-strict-rules": "^1",
@@ -377,7 +378,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.4-dev"
+                    "dev-main": "2.5-dev"
                 },
                 "phpstan": {
                     "includes": [
@@ -416,7 +417,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
-                "source": "https://github.com/composer/composer/tree/2.4.4"
+                "source": "https://github.com/composer/composer/tree/2.5.7"
             },
             "funding": [
                 {
@@ -432,7 +433,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-27T12:39:29+00:00"
+            "time": "2023-05-24T13:00:40+00:00"
         },
         {
             "name": "composer/metadata-minifier",
@@ -4480,6 +4481,85 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/polyfill-php80/tree/v1.27.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-11-03T14:55:06+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php81",
+            "version": "v1.27.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php81.git",
+                "reference": "707403074c8ea6e2edaf8794b0157a0bfa52157a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/707403074c8ea6e2edaf8794b0157a0bfa52157a",
+                "reference": "707403074c8ea6e2edaf8794b0157a0bfa52157a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.27-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.27.0"
             },
             "funding": [
                 {

--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -286,6 +286,12 @@ class ComponentInstaller implements
         $installer    = $this->composer->getInstallationManager();
         $packagePath  = $installer->getInstallPath($package);
 
+        /** @psalm-suppress TypeDoesNotContainNull Package path become nullable in composer 2.5.6 */
+        if ($packagePath === null || $packagePath === '') {
+            // Do not try to discover dependencies for metapackage and other
+            // potential package types that have no install location.
+            return [];
+        }
         $this->mapAutoloaders($package->getAutoload(), $dependencies, $packagePath);
 
         return $dependencies->getArrayCopy();

--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -286,7 +286,6 @@ class ComponentInstaller implements
         $installer    = $this->composer->getInstallationManager();
         $packagePath  = $installer->getInstallPath($package);
 
-        /** @psalm-suppress TypeDoesNotContainNull Package path become nullable in composer 2.5.6 */
         if ($packagePath === null || $packagePath === '') {
             // Do not try to discover dependencies for metapackage and other
             // potential package types that have no install location.
@@ -754,7 +753,7 @@ class ComponentInstaller implements
      *
      * @param AutoloadRules       $autoload     List of autoloader types and associated autoloader definitions.
      * @param ArrayObject $dependencies Module dependencies defined by the module.
-     * @param string      $packagePath  Path to the package on the filesystem.
+     * @param non-empty-string $packagePath  Path to the package on the filesystem.
      * @psalm-param ArrayObject<non-empty-string,list<non-empty-string>>                   $dependencies
      */
     private function mapAutoloaders(array $autoload, ArrayObject $dependencies, string $packagePath): void
@@ -770,7 +769,7 @@ class ComponentInstaller implements
      * @param array       $map          Map of namespace => path(s) pairs.
      * @param string      $type         Type of autoloader being iterated.
      * @param ArrayObject $dependencies Module dependencies defined by the module.
-     * @param string      $packagePath  Path to the package on the filesystem.
+     * @param non-empty-string $packagePath  Path to the package on the filesystem.
      * @psalm-param array<int|string, array<array-key, string>|string>           $map
      * @psalm-param ArrayObject<non-empty-string,list<non-empty-string>>  $dependencies
      */
@@ -789,7 +788,7 @@ class ComponentInstaller implements
      * @param string|int  $namespace    PHP namespace to which the paths map or index of file/directory list.
      * @param string      $type         Type of autoloader being iterated.
      * @param ArrayObject $dependencies Module dependencies defined by the module.
-     * @param string      $packagePath  Path to the package on the filesystem.
+     * @param non-empty-string $packagePath  Path to the package on the filesystem.
      * @psalm-param list<string> $paths
      * @psalm-param ArrayObject<non-empty-string,list<non-empty-string>> $dependencies
      */
@@ -812,7 +811,7 @@ class ComponentInstaller implements
      * @param string|int  $namespace    PHP namespace to which the paths map.
      * @param string      $type         Type of autoloader being iterated.
      * @param ArrayObject $dependencies Module dependencies defined by the module.
-     * @param string      $packagePath  Path to the package on the filesystem.
+     * @param non-empty-string $packagePath  Path to the package on the filesystem.
      * @psalm-param ArrayObject<non-empty-string,list<non-empty-string>> $dependencies
      */
     private function mapPath(


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
Composer metapackages are not installed same way as other packages. With no install location there is nothing to discover even if metapackage tries to define autoloading rules for whatever reason. No change in effective behavior is introduced.

Starting with composer 2.5.6 the return type for `Composer\Installer\InstallationManager::getInstallPath()` method becomes nullable. This change fixes type error produced for metapackages with defined extras.

Fixes #69 
